### PR TITLE
Fix: Resolve TypeError for undefined val().trim() in hotel script

### DIFF
--- a/assets/frontend/ttbm_hotel_script.js
+++ b/assets/frontend/ttbm_hotel_script.js
@@ -14,7 +14,8 @@ jQuery(document).ready(function ($) {
     let tomorrow = new Date();
     tomorrow.setDate(today.getDate() + 1);
 
-    let hotel_id = $("#ttbm_booking_hotel_id").val().trim();
+    let hotel_id = $("#ttbm_booking_hotel_id").val();
+    hotel_id = hotel_id ? hotel_id.trim() : '';
     let date_range = `${formatDate(today)}    -    ${formatDate(tomorrow)}`;
     $('[name="ttbm_hotel_date_range"]').val(date_range);
     if ($('[name="ttbm_hotel_date_range"]').length > 1) {
@@ -51,7 +52,8 @@ jQuery(document).ready(function ($) {
         let current = $(this).closest('.ttbm_hotel_item');
         
         // let hotel_id = current.find('[name="ttbm_tour_hotel_list"]').val();
-        let hotel_id = $("#ttbm_booking_hotel_id").val().trim();
+        let hotel_id = $("#ttbm_booking_hotel_id").val();
+        hotel_id = hotel_id ? hotel_id.trim() : '';
         let date_range = $('[name="ttbm_hotel_date_range"]').val();
         if ($('[name="ttbm_hotel_date_range"]').length > 1) {
             date_range = $(this).closest('.particular_date_area').find('[name="ttbm_hotel_date_range"]').val();
@@ -83,7 +85,8 @@ jQuery(document).ready(function ($) {
     });
     $(document).on('click', '.ttbm_hotel_book_now', function (e) {
         e.preventDefault();
-        let hotel_id = $("#ttbm_booking_hotel_id").val().trim();
+        let hotel_id = $("#ttbm_booking_hotel_id").val();
+        hotel_id = hotel_id ? hotel_id.trim() : '';
         let date_range = $('[name="ttbm_hotel_date_range"]').val();
         if ($('[name="ttbm_hotel_date_range"]').length > 1) {
             date_range = $(this).closest('.particular_date_area').find('[name="ttbm_hotel_date_range"]').val();


### PR DESCRIPTION
Problem:
- JavaScript TypeError: can't access property 'trim', .val() is undefined
- Error occurred in ttbm_hotel_script.js at lines 17, 54, and 86
- Happens when #ttbm_booking_hotel_id element doesn't exist or returns undefined
- Breaks hotel booking functionality and prevents room availability checks

Root Cause:
- Code directly calls .trim() on jQuery .val() result without null/undefined checks
- If #ttbm_booking_hotel_id element is missing or has no value, .val() returns undefined
- Calling .trim() on undefined throws TypeError

Solution:
- Line 17-18: Added null check before trim() in document.ready function
- Line 55-56: Added null check before trim() in room availability click handler
- Line 88-89: Added null check before trim() in hotel booking click handler
- Pattern: let hotel_id = element.val(); hotel_id = hotel_id ? hotel_id.trim() : '';

Benefits:
- Prevents JavaScript errors when hotel_id element is missing
- Maintains backward compatibility with existing functionality
- Provides safe fallback (empty string) when element is undefined
- Ensures hotel booking features continue to work even with DOM issues

Technical Details:
- Uses ternary operator for concise null/undefined checking
- Maintains original trimming behavior when value exists
- Gracefully degrades to empty string when value is missing
- No breaking changes to existing API or functionality

Files Changed:
- assets/frontend/ttbm_hotel_script.js (3 locations updated)

Browser Compatibility: All modern browsers supporting ES6