### PR TITLE
Fix: Date Configuration save and expired validation issues

### DIFF
--- a/admin/settings/tour/TTBM_Settings.php
+++ b/admin/settings/tour/TTBM_Settings.php
@@ -376,6 +376,14 @@
 					if ($ttbm_repeat_type == 'occurrence' && $ttbm_travel_repeated_end_date) {
 						$day_count = $ttbm_repeat_number * $ttbm_travel_repeated_after;
 						$ttbm_travel_repeated_end_date = gmdate('Y-m-d', strtotime($ttbm_travel_repeated_start_date . ' +' . $day_count . ' day'));
+					} elseif ($ttbm_repeat_type == 'fixed' && $ttbm_travel_repeated_end_date) {
+						// Format the end date to Y-m-d when repeat type is 'fixed' (On)
+						$parsed_date = strtotime($ttbm_travel_repeated_end_date);
+						if ($parsed_date !== false) {
+							$ttbm_travel_repeated_end_date = gmdate('Y-m-d', $parsed_date);
+						} else {
+							$ttbm_travel_repeated_end_date = '';
+						}
 					}
 					update_post_meta($tour_id, 'ttbm_travel_repeated_end_date', $ttbm_travel_repeated_end_date);
 					$display_time = isset($_POST['mep_disable_ticket_time']) && sanitize_text_field(wp_unslash($_POST['mep_disable_ticket_time'])) ? 'yes' : 'no';

--- a/assets/mp_style/ttbm_plugin_global.js
+++ b/assets/mp_style/ttbm_plugin_global.js
@@ -118,6 +118,37 @@ function ttbm_load_date_picker(parent = jQuery('.ttbm_style')) {
             }
         });
     });
+    // Clear hidden field when visible date field is cleared - using event delegation for better reliability
+    parent.off('input.ttbm_clear_date change.ttbm_clear_date blur.ttbm_clear_date', '.date_type, .date_type_without_year');
+    parent.on('input.ttbm_clear_date change.ttbm_clear_date blur.ttbm_clear_date', '.date_type, .date_type_without_year', function() {
+        let $this = jQuery(this);
+        let currentValue = $this.val();
+        if (!currentValue || currentValue.trim() === '') {
+            let $hiddenField = $this.closest('label').find('input[type="hidden"]');
+            if ($hiddenField.length) {
+                $hiddenField.val('').trigger('change');
+            }
+        }
+    });
+    // Ensure cleared dates are saved before form submission
+    let $form = parent.closest('form');
+    if ($form.length === 0) {
+        $form = jQuery('#post, #post-form, form[name="post"]');
+    }
+    if ($form.length > 0) {
+        $form.off('submit.ttbm_clear_dates').on('submit.ttbm_clear_dates', function() {
+            parent.find('.date_type, .date_type_without_year').each(function() {
+                let $this = jQuery(this);
+                let currentValue = $this.val();
+                if (!currentValue || currentValue.trim() === '') {
+                    let $hiddenField = $this.closest('label').find('input[type="hidden"]');
+                    if ($hiddenField.length && $hiddenField.val()) {
+                        $hiddenField.val('');
+                    }
+                }
+            });
+        });
+    }
 }
 //========================================================Alert==============//
 function ttbm_alert($this, attr = 'alert') {
@@ -129,6 +160,25 @@ function ttbm_alert($this, attr = 'alert') {
     $(document).ready(function () {
         ttbm_load_date_picker();
         $('.ttbm_select2').select2({});
+        
+        // Clear hidden date fields when visible fields are cleared - global handler for WordPress admin
+        function clearEmptyDateFields() {
+            $('.date_type, .date_type_without_year').each(function() {
+                let $this = $(this);
+                let currentValue = $this.val();
+                if (!currentValue || currentValue.trim() === '') {
+                    let $hiddenField = $this.closest('label').find('input[type="hidden"]');
+                    if ($hiddenField.length && $hiddenField.val()) {
+                        $hiddenField.val('');
+                    }
+                }
+            });
+        }
+        
+        // Clear dates before WordPress save/update
+        $(document).on('click', '#publish, #save-post, input[name="save"], input[name="publish"]', function() {
+            clearEmptyDateFields();
+        });
     });
 }(jQuery));
 //====================================================================Load Bg Image=================//


### PR DESCRIPTION
Fixed multiple issues with Date Configuration:

1. Date Field Clearing Issue:
   - Fixed issue where clearing/removing date fields in Date Configuration (Fixed Dates, Particular Dates, Repeated Dates) was not being saved
   - Added JavaScript event handlers to clear hidden date fields when visible fields are cleared (input, change, blur events)
   - Added form submission handler to ensure cleared dates are saved before form submission
   - Added WordPress publish/update button click handler as additional safety net

2. Repeated Dates End Date Formatting:
   - Fixed issue where 'End Repeat' set to 'On' (fixed type) was not properly formatting the end date to Y-m-d format before saving
   - Added proper date formatting and validation when repeat_type is 'fixed'
   - Improved end date validation in get_date() function to handle invalid dates

3. Repeated Dates Expired Validation:
   - Fixed infinite loop issue in get_date_by_time_check() function
   - Removed recursive call to get_date() which was causing stack overflow
   - Implemented direct validation for repeated dates without recursion:
     * Validates date is within start/end date range
     * Checks if date matches interval pattern (daily, weekly, monthly) * Validates against off days and off dates * Properly validates time/expiration
   - Fixed issue where valid repeated dates were showing as 'Expired!' on frontend

Files Modified:
- admin/settings/tour/TTBM_Settings.php: Added end date formatting for fixed repeat type
- assets/mp_style/ttbm_plugin_global.js: Added date clearing handlers and form submission checks
- inc/TTBM_Function.php: Fixed infinite loop and improved repeated date validation