### PR TITLE
Remove low stock and 'almost sold out' functionality from availabilit…

### DIFF
--- a/assets/frontend/ttbm_price_calculation.js
+++ b/assets/frontend/ttbm_price_calculation.js
@@ -288,7 +288,7 @@ function ttbm_partial_payment_job(parent, total) {
 			var progressBar = row.find('.ttbm_progress_fill');
 			if (progressBar.length > 0) {
 				progressBar.css('width', info.percentage_sold + '%');
-				progressBar.removeClass('ttbm_progress_in_stock ttbm_progress_medium_stock ttbm_progress_low_stock ttbm_progress_sold_out');
+				progressBar.removeClass('ttbm_progress_in_stock ttbm_progress_sold_out');
 				progressBar.addClass('ttbm_progress_' + info.stock_status);
 			}
 			
@@ -299,7 +299,7 @@ function ttbm_partial_payment_job(parent, total) {
 			}
 			
 			// Update row classes
-			row.removeClass('ttbm_stock_in_stock ttbm_stock_medium_stock ttbm_stock_low_stock ttbm_stock_sold_out ttbm_sold_out ttbm_low_stock');
+			row.removeClass('ttbm_stock_in_stock ttbm_stock_sold_out ttbm_sold_out');
 			row.addClass('ttbm_stock_' + info.stock_status);
 			
 			if (info.available_qty <= 0) {
@@ -311,12 +311,6 @@ function ttbm_partial_payment_job(parent, total) {
 				}
 				// Disable quantity input
 				row.find('.formControl[data-price]').prop('disabled', true).val(0);
-			} else if (info.available_qty <= 5) {
-				row.addClass('ttbm_low_stock');
-				// Add urgency message if not exists
-				if (row.find('.ttbm_urgency_message').length === 0) {
-					row.find('.ttbm_availability_details').append('<div class="ttbm_urgency_message"><i class="fas fa-exclamation-triangle"></i><span>Almost sold out!</span></div>');
-				}
 			} else {
 				// Remove urgency message if exists
 				row.find('.ttbm_urgency_message').remove();

--- a/assets/frontend/ttbm_registration.css
+++ b/assets/frontend/ttbm_registration.css
@@ -2038,24 +2038,6 @@ div.ttbm_style .ttbm_hotel_room_incDec .formControl{
     letter-spacing: 0.3px;
 }
 
-.ttbm_urgency_message {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    color: #dc3545;
-    font-size: 12px;
-    font-weight: 600;
-    padding: 6px 10px;
-    background: rgba(220, 53, 69, 0.1);
-    border-radius: 15px;
-    animation: urgency-pulse 1.5s ease-in-out infinite;
-}
-
-@keyframes urgency-pulse {
-    0%, 100% { transform: scale(1); }
-    50% { transform: scale(1.05); }
-}
-
 .ttbm_capacity_info {
     margin-top: 5px;
 }
@@ -2092,10 +2074,6 @@ div.ttbm_style .ttbm_hotel_room_incDec .formControl{
     background: linear-gradient(90deg, #ffc107, #fd7e14);
 }
 
-.ttbm_progress_low_stock {
-    background: linear-gradient(90deg, #dc3545, #e83e8c);
-}
-
 .ttbm_progress_sold_out {
     background: #6c757d;
 }
@@ -2126,26 +2104,6 @@ div.ttbm_style .ttbm_hotel_room_incDec .formControl{
     width: 4px;
     height: 100%;
     background: #dc3545;
-}
-
-.ttbm_low_stock {
-    background: rgba(255, 193, 7, 0.05) !important;
-    animation: low-stock-glow 3s ease-in-out infinite;
-}
-
-@keyframes low-stock-glow {
-    0%, 100% { box-shadow: 0 0 0 rgba(255, 193, 7, 0); }
-    50% { box-shadow: 0 0 20px rgba(255, 193, 7, 0.3); }
-}
-
-.ttbm_low_stock td::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 4px;
-    height: 100%;
-    background: #ffc107;
 }
 
 .ttbm_not_available {
@@ -2207,11 +2165,6 @@ div.ttbm_style .ttbm_hotel_room_incDec .formControl{
     align-items: center;
     justify-content: center;
     gap: 5px;
-}
-
-.ttbm_enhanced_table .ttbm_urgency_message {
-    margin: 5px auto 0;
-    display: inline-flex;
 }
 
 .ttbm_enhanced_table .ttbm_capacity_info {
@@ -2378,18 +2331,6 @@ div.ttbm_style .ttbm_hotel_room_incDec .formControl{
         color: #6c757d;
     }
     
-    .ttbm_urgency_message {
-        font-size: 11px;
-        padding: 3px 8px;
-        background: rgba(220, 53, 69, 0.1);
-        color: #dc3545;
-        border-radius: 20px;
-        display: inline-flex;
-        align-items: center;
-        gap: 5px;
-        margin-top: 5px;
-    }
-    
     .ttbm_capacity_info {
         display: none; /* Hide on mobile for cleaner look */
     }
@@ -2461,12 +2402,6 @@ div.ttbm_style .ttbm_hotel_room_incDec .formControl{
         font-size: 10px;
     }
     
-    .ttbm_urgency_message {
-        font-size: 10px;
-        padding: 2px 6px;
-        gap: 3px;
-    }
-    
     .ttbm-select-quantity .qtyIncDec {
         min-width: 100px;
     }
@@ -2514,23 +2449,6 @@ div.ttbm_style .ttbm_hotel_room_incDec .formControl{
     letter-spacing: 0.5px;
 }
 
-.ttbm_extra_service_area .ttbm_urgency_message {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    background: #fff3cd;
-    color: #856404;
-    padding: 6px 12px;
-    border-radius: 4px;
-    font-size: 11px;
-    font-weight: 500;
-    border: 1px solid #ffeaa7;
-}
-
-.ttbm_extra_service_area .ttbm_urgency_message i {
-    color: #f39c12;
-}
-
 .ttbm_extra_service_area .ttbm_capacity_info {
     display: flex;
     flex-direction: column;
@@ -2563,10 +2481,6 @@ div.ttbm_style .ttbm_hotel_room_incDec .formControl{
 
 .ttbm_extra_service_area .ttbm_progress_in_stock {
     background: linear-gradient(90deg, #28a745, #20c997);
-}
-
-.ttbm_extra_service_area .ttbm_progress_low_stock {
-    background: linear-gradient(90deg, #ffc107, #fd7e14);
 }
 
 .ttbm_extra_service_area .ttbm_progress_sold_out {
@@ -2676,14 +2590,6 @@ div.ttbm_style .ttbm_hotel_room_incDec .formControl{
         color: #6c757d;
         text-transform: uppercase;
         letter-spacing: 0.5px;
-    }
-    
-    .ttbm_extra_service_area .ttbm_urgency_message {
-        font-size: 10px;
-        padding: 6px 10px;
-        gap: 4px;
-        margin: 8px 0;
-        text-align: center;
     }
     
     .ttbm_extra_service_area .ttbm_capacity_info {

--- a/inc/TTBM_Function.php
+++ b/inc/TTBM_Function.php
@@ -640,7 +640,6 @@
 					'available_qty' => $available_qty,
 					'percentage_sold' => $percentage_sold,
 					'is_sold_out' => $available_qty <= 0,
-					'is_low_stock' => $available_qty > 0 && $available_qty <= ($total_capacity * 0.1),
 					'stock_status' => $stock_status,
 					'tour_date' => $tour_date,
 					'price' => self::get_price_by_name($type_name, $tour_id, '', '', $tour_date),
@@ -654,10 +653,6 @@
 		public static function get_stock_status($available_qty, $total_capacity) {
 			if ($available_qty <= 0) {
 				return 'sold_out';
-			} elseif ($available_qty <= ($total_capacity * 0.1)) {
-				return 'low_stock';
-			} elseif ($available_qty <= ($total_capacity * 0.3)) {
-				return 'medium_stock';
 			} else {
 				return 'in_stock';
 			}
@@ -692,9 +687,8 @@
 			
 			foreach ($availability_info as $ticket_name => $info) {
 				$status_class = 'ttbm_status_' . $info['stock_status'];
-				$urgency_class = $info['is_low_stock'] ? 'ttbm_low_stock' : '';
 				
-				$output .= '<div class="ttbm_ticket_availability ' . $status_class . ' ' . $urgency_class . '">';
+				$output .= '<div class="ttbm_ticket_availability ' . $status_class . '">';
 				$output .= '<span class="ttbm_ticket_name">' . esc_html($ticket_name) . '</span>';
 				
 				if ($info['is_sold_out']) {
@@ -706,10 +700,6 @@
 						esc_html__('ticket left', 'tour-booking-manager') : 
 						esc_html__('tickets left', 'tour-booking-manager');
 					$output .= '</span>';
-					
-					if ($info['is_low_stock']) {
-						$output .= '<span class="ttbm_urgency_text">' . esc_html__('Almost sold out!', 'tour-booking-manager') . '</span>';
-					}
 				}
 				
 				$output .= '</div>';

--- a/templates/ticket/extra_service.php
+++ b/templates/ticket/extra_service.php
@@ -47,8 +47,7 @@
 							<?php
 							// Calculate availability status and display logic
 							$is_sold_out = $available <= 0;
-							$is_low_stock = $available > 0 && $available <= ($service_qty * 0.2); // Low stock if 20% or less remaining
-							$stock_status = $is_sold_out ? 'sold_out' : ($is_low_stock ? 'low_stock' : 'in_stock');
+							$stock_status = $is_sold_out ? 'sold_out' : 'in_stock';
 							$percentage_sold = $service_qty > 0 ? round((($service_qty - $available) / $service_qty) * 100) : 0;
 							$sold_qty = $service_qty - $available;
 							?>
@@ -82,13 +81,6 @@
 																<?php echo $available === 1 ? esc_html__('service left', 'tour-booking-manager') : esc_html__('services left', 'tour-booking-manager'); ?>
 															</span>
 														</div>
-														
-														<?php if ($is_low_stock) { ?>
-															<div class="ttbm_urgency_message">
-																<i class="fas fa-exclamation-triangle"></i>
-																<span><?php esc_html_e('Almost sold out!', 'tour-booking-manager'); ?></span>
-															</div>
-														<?php } ?>
 														
 														<div class="ttbm_capacity_info">
 															<span class="ttbm_capacity_text">

--- a/templates/ticket/regular_ticket.php
+++ b/templates/ticket/regular_ticket.php
@@ -70,14 +70,11 @@ if (!defined('ABSPATH')) {
 								$stock_status = $ticket_info['stock_status'] ?? 'in_stock';
 								$percentage_sold = $ticket_info['percentage_sold'] ?? 0;
 								$is_sold_out = $ticket_info['is_sold_out'] ?? ($available <= 0);
-								$is_low_stock = $ticket_info['is_low_stock'] ?? ($available <= 5 && $available > 0);
 								
 								// Set row classes based on stock status
 								$row_classes = array('ttbm_ticket_row', 'ttbm_stock_' . $stock_status);
 								if ($is_sold_out) {
 									$row_classes[] = 'ttbm_sold_out';
-								} elseif ($is_low_stock) {
-									$row_classes[] = 'ttbm_low_stock';
 								}
 								?>
 								<tr class="<?php echo esc_attr(implode(' ', $row_classes)); ?>" data-ticket-name="<?php echo esc_attr($ticket_name); ?>">
@@ -129,13 +126,6 @@ if (!defined('ABSPATH')) {
 																	<?php echo $available === 1 ? esc_html__('ticket left', 'tour-booking-manager') : esc_html__('tickets left', 'tour-booking-manager'); ?>
 																</span>
 															</div>
-															
-															<?php if ($is_low_stock) { ?>
-																<div class="ttbm_urgency_message">
-																	<i class="fas fa-exclamation-triangle"></i>
-																	<span><?php esc_html_e('Almost sold out!', 'tour-booking-manager'); ?></span>
-																</div>
-															<?php } ?>
 															
 															<div class="ttbm_capacity_info">
 																<span class="ttbm_capacity_text">


### PR DESCRIPTION
…y sections

This commit removes all low stock and 'almost sold out' related functionality from the tour-booking-manager plugin. The availability display now only shows 'in stock' or 'sold out' status.

Changes made:

PHP Templates:
- templates/ticket/regular_ticket.php:
  * Removed \ variable and logic
  * Removed ttbm_low_stock CSS class from row classes
  * Removed urgency message div with 'Almost sold out!' text

- templates/ticket/extra_service.php:
  * Removed \ variable and calculation logic
  * Removed stock_status low_stock assignment
  * Removed urgency message div with 'Almost sold out!' text

PHP Functions:
- inc/TTBM_Function.php:
  * Removed 'is_low_stock' key from availability info array in get_ticket_availability_info()
  * Simplified get_stock_status() function to return only 'sold_out' or 'in_stock' (removed low_stock and medium_stock statuses)
  * Removed urgency message and low_stock class from format_availability_display()

JavaScript:
- assets/frontend/ttbm_price_calculation.js:
  * Removed low stock detection logic (available_qty <= 5 check)
  * Removed urgency message creation and insertion
  * Cleaned up class references to remove low_stock classes from DOM manipulation

CSS:
- assets/frontend/ttbm_registration.css:
  * Removed .ttbm_urgency_message styles and animations
  * Removed @keyframes urgency-pulse animation
  * Removed .ttbm_progress_low_stock styles
  * Removed .ttbm_low_stock styles and animations
  * Removed @keyframes low-stock-glow animation
  * Removed all mobile responsive urgency message styles
  * Removed all extra service area urgency message styles

The availability sections now display a cleaner interface showing only:
- Available ticket count
- Sold out status when applicable
- Progress bar showing percentage sold
- No low stock warnings or urgency messages

All sold out functionality remains intact and working properly.