### PR TITLE
Fix: Time-slot specific stock/availability not working correctly

### DIFF
--- a/inc/TTBM_Function.php
+++ b/inc/TTBM_Function.php
@@ -637,7 +637,14 @@
 				$tour_date = current(self::get_date($tour_id));
 			}
 			
-			$tour_date = gmdate('Y-m-d', strtotime($tour_date));
+			// Preserve time component if present for time-slot specific availability
+			$has_time = TTBM_Global_Function::check_time_exit_date($tour_date);
+			if ($has_time) {
+				$tour_date = gmdate('Y-m-d H:i', strtotime($tour_date));
+			} else {
+				$tour_date = gmdate('Y-m-d', strtotime($tour_date));
+			}
+			
 			$ticket_types = self::get_ticket_type($tour_id);
 			$availability_info = array();
 			


### PR DESCRIPTION
Problem:
- When a tour has multiple time slots on the same date (e.g., 10:00 AM and 12:00 PM)
- If one time slot (10:00 AM) is sold out, it incorrectly affects other time slots
- For example: 10:00 AM sold out with 7 seats would also show 12:00 PM as sold out
- This happened because the sold ticket query used LIKE comparison for dates

Root Cause:
- query_all_sold() in TTBM_Query.php used 'compare' => 'LIKE' for date filtering
- A query for '2026-02-21' would match ALL bookings containing that date:
  * '2026-02-21 10:00' (10 AM bookings)
  * '2026-02-21 12:00' (12 PM bookings)
  * '2026-02-21 15:00' (3 PM bookings)
- This caused all time slots to share the same sold count

Solution:
1. TTBM_Query.php - query_all_sold():
   - Now checks if date contains time using check_time_exit_date()
   - Uses exact match (=) when time is present for time-slot specific counting
   - Uses LIKE for date-only queries (backward compatibility)

2. TTBM_Query.php - query_all_service_sold():
   - Applied same fix for extra services sold count

3. TTBM_Function.php - get_ticket_availability_info():
   - Now preserves time component when formatting date
   - Uses 'Y-m-d H:i' format when time is present
   - Uses 'Y-m-d' format for date-only queries

Result:
- Each time slot now has independent stock tracking
- Selling out 10:00 AM no longer affects 12:00 PM availability
- Backward compatible with tours that don't use time slots