### PR TITLE
Fix ttbm-top-search shortcode filter options not working

### DIFF
--- a/admin/TTBM_CPT.php
+++ b/admin/TTBM_CPT.php
@@ -82,6 +82,7 @@
 					'supports' => array( 'title' ),
 					'show_in_menu' => 'edit.php?post_type=ttbm_tour',
 					'capability_type' => 'post',
+					'show_in_rest' => true,
 				);
 				register_post_type( 'ttbm_ticket_types', $args );
 			
@@ -113,6 +114,7 @@ register_post_type('ttbm_hotel', $args);
 					// 'show_in_menu' => 'edit.php?post_type=ttbm_tour',
 					'show_in_menu' => false,
 					'capability_type' => 'post',
+					'show_in_rest' => true,
 				];
 				register_post_type('ttbm_places', $args);
 				$args = [
@@ -121,6 +123,7 @@ register_post_type('ttbm_hotel', $args);
 					'supports' => ['title', 'thumbnail', 'editor'],
 					'show_in_menu' => 'edit.php?post_type=ttbm_tour',
 					'capability_type' => 'post',
+					'show_in_rest' => true,
 				];
 				register_post_type('ttbm_guide', $args);
 

--- a/inc/TTBM_Filter_Pagination.php
+++ b/inc/TTBM_Filter_Pagination.php
@@ -79,7 +79,7 @@
 			public function title_filter($params) {
 				if ($params['title-filter'] == 'yes') {
 					$title_filter = '';
-					if (isset($_POST['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
+					if (isset($_GET['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
 						$title_filter = isset($_GET['title_filter']) ? sanitize_text_field(wp_unslash($_GET['title_filter'])) : '';
 					}
 					?>
@@ -107,7 +107,7 @@
 			public function type_filter($params) {
 				if ($params['type-filter'] == 'yes') {
 					$url = '';
-					if (isset($_POST['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
+					if (isset($_GET['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
 						$url = isset($_GET['type_filter']) ? sanitize_text_field(wp_unslash($_GET['type_filter'])) : '';
 					}
 					?>
@@ -141,7 +141,7 @@
 					$categories = is_array($categories) ? $categories : TTBM_Global_Function::get_taxonomy('ttbm_tour_cat');
 					if (is_array($categories) && sizeof($categories) > 0) {
 						$category_filter = '';
-						if (isset($_POST['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
+						if (isset($_GET['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
 							$category_filter = isset($_GET['category_filter']) ? sanitize_text_field(wp_unslash($_GET['category_filter'])) : '';
 						}
 						$url = $category_filter;
@@ -182,7 +182,7 @@
 					$organizers = sizeof($organizers) > 0 ? $organizers : TTBM_Global_Function::get_taxonomy('ttbm_tour_org', 'ttbm_tour');
 					if (sizeof($organizers) > 0) {
 						$organizer_filter = '';
-						if (isset($_POST['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
+						if (isset($_GET['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
 							$organizer_filter = isset($_GET['organizer_filter']) ? sanitize_text_field(wp_unslash($_GET['organizer_filter'])) : '';
 						}
 						$url = $organizer_filter;
@@ -231,7 +231,7 @@
 					$locations = TTBM_Global_Function::get_taxonomy('ttbm_tour_location');
 					if (sizeof($locations) > 0) {
 						$location_filter = '';
-						if (isset($_POST['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
+						if (isset($_GET['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
 							$location_filter = isset($_GET['location_filter']) ? sanitize_text_field(wp_unslash($_GET['location_filter'])) : '';
 						}
 						$url = $location_filter;
@@ -271,7 +271,7 @@
 					$exist_locations = array_unique($exist_locations);
 					if (sizeof($exist_locations) > 0) {
 						$url_location = '';
-						if (isset($_POST['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
+						if (isset($_GET['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
 							$url_location = isset($_GET['location_filter']) ? sanitize_text_field(wp_unslash($_GET['location_filter'])) : '';
 						}
 						$current_location = $url_location ? (($term = get_term_by('id', $url_location, 'ttbm_tour_location')) ? $term->term_id : '') : '';
@@ -307,7 +307,7 @@
 					$countries = is_array($countries) ? $countries : TTBM_Function::get_all_country();
 					if (sizeof($countries) > 0) {
 						$url = '';
-						if (isset($_POST['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
+						if (isset($_GET['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
 							$url = isset($_GET['country_filter']) ? sanitize_text_field(wp_unslash($_GET['country_filter'])) : '';
 						}
 						?>
@@ -347,7 +347,7 @@
 					$durations = TTBM_Function::get_all_duration();
 					if (sizeof($durations) > 0) {
 						$url = '';
-						if (isset($_POST['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
+						if (isset($_GET['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
 							$url = isset($_GET['duration_filter']) ? sanitize_text_field(wp_unslash($_GET['duration_filter'])) : '';
 						}
 						?>
@@ -378,7 +378,7 @@
 					$durations = TTBM_Function::get_all_duration();
 					if (sizeof($durations) > 0) {
 						$url = '';
-						if (isset($_POST['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
+						if (isset($_GET['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
 							$url = isset($_GET['duration_filter']) ? sanitize_text_field(wp_unslash($_GET['duration_filter'])) : '';
 						}
 						?>
@@ -432,7 +432,7 @@
 					}
 					if (sizeof($exist_feature) > 0) {
 						$url = '';
-						if (isset($_POST['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
+						if (isset($_GET['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
 							$url = isset($_GET['feature_filter']) ? sanitize_text_field(wp_unslash($_GET['feature_filter'])) : '';
 						}
 						?>
@@ -467,7 +467,7 @@
 					$activities = TTBM_Global_Function::get_taxonomy('ttbm_tour_activities');
 					if (sizeof($activities) > 0) {
 						$url_activity = '';
-						if (isset($_POST['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
+						if (isset($_GET['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
 							$url_activity = isset($_GET['activity_filter']) ? sanitize_text_field(wp_unslash($_GET['activity_filter'])) : '';
 						}
 						$current_activity = $url_activity ? (($term = get_term_by('id', $url_activity, 'ttbm_tour_activities')) ? $term->term_id : '') : '';
@@ -501,7 +501,7 @@
 					}
 					if (sizeof($exist_activities) > 0) {
 						$url_activity = '';
-						if (isset($_POST['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
+						if (isset($_GET['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
 							$url_activity = isset($_GET['activity_filter']) ? sanitize_text_field(wp_unslash($_GET['activity_filter'])) : '';
 						}
 						$current_activity = $url_activity ? (($term = get_term_by('id', $url_activity, 'ttbm_tour_activities')) ? $term->term_id : '') : '';
@@ -558,7 +558,7 @@
 					}
 					if (sizeof($unique_activities) > 0) {
 						$url_activity = '';
-						if (isset($_POST['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
+						if (isset($_GET['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
 							$url_activity = isset($_GET['activity_filter']) ? sanitize_text_field(wp_unslash($_GET['activity_filter'])) : '';
 						}
 						$current_activity = $url_activity ? (($term = get_term_by('id', $url_activity, 'ttbm_tour_activities')) ? $term->term_id : '') : '';
@@ -632,7 +632,7 @@
 			public function month_filter($params) {
 				if ($params['month-filter'] == 'yes') {
 					$url_month = '';
-					if (isset($_POST['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
+					if (isset($_GET['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
 						$url_month = isset($_GET['month_filter']) ? sanitize_text_field(wp_unslash($_GET['month_filter'])) : '';
 					}
 					$first_date = gmdate('Y-m-01');

--- a/inc/TTBM_Global_Function.php
+++ b/inc/TTBM_Global_Function.php
@@ -498,13 +498,22 @@
 				}
 			}
 			public static function get_order_item_meta( $item_id, $key ): string {
+				$value = wc_get_order_item_meta( $item_id, $key, true );
+				if ( is_array( $value ) ) {
+					return maybe_serialize( $value );
+				}
+				if ( is_string( $value ) ) {
+					return $value;
+				}
+				if ( ! empty( $value ) || $value === 0 || $value === '0' ) {
+					return (string) $value;
+				}
 				global $wpdb;
 				$table_name = $wpdb->prefix . "woocommerce_order_itemmeta";
 				$results    = $wpdb->get_results( $wpdb->prepare( "SELECT meta_value FROM $table_name WHERE order_item_id = %d AND meta_key = %s", $item_id, $key ) );
 				foreach ( $results as $result ) {
 					$value = $result->meta_value;
 				}
-
 				return $value ?? '';
 			}
 			public static function wc_product_sku($product_id) {
@@ -1093,13 +1102,22 @@
 				}
 			}
 			public static function get_order_item_meta( $item_id, $key ): string {
+				$value = wc_get_order_item_meta( $item_id, $key, true );
+				if ( is_array( $value ) ) {
+					return maybe_serialize( $value );
+				}
+				if ( is_string( $value ) ) {
+					return $value;
+				}
+				if ( ! empty( $value ) || $value === 0 || $value === '0' ) {
+					return (string) $value;
+				}
 				global $wpdb;
 				$table_name = $wpdb->prefix . "woocommerce_order_itemmeta";
 				$results    = $wpdb->get_results( $wpdb->prepare( "SELECT meta_value FROM $table_name WHERE order_item_id = %d AND meta_key = %s", $item_id, $key ) );
 				foreach ( $results as $result ) {
 					$value = $result->meta_value;
 				}
-
 				return $value ?? '';
 			}
 			public static function wc_product_sku($product_id) {

--- a/inc/TTBM_Tour_List.php
+++ b/inc/TTBM_Tour_List.php
@@ -24,7 +24,7 @@
 				$tag_filter = '';
 				$duration_filter = '';
 				$activity_filter = '';
-				if (isset($_POST['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
+				if (isset($_GET['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
 					$category_filter = isset($_GET['category_filter']) ? sanitize_text_field(wp_unslash($_GET['category_filter'])) : '';
 					$title_filter = isset($_GET['title_filter']) ? sanitize_text_field(wp_unslash($_GET['title_filter'])) : '';
 					$type_filter = isset($_GET['type_filter']) ? sanitize_text_field(wp_unslash($_GET['type_filter'])) : '';

--- a/templates/layout/filter_hidden.php
+++ b/templates/layout/filter_hidden.php
@@ -3,6 +3,7 @@
 		die;
 	} // Cannot access pages directly.
 	if (isset($_GET['ttbm_search_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['ttbm_search_nonce'])), 'ttbm_search_nonce')) {
+		$title_filter = isset($_GET['title_filter']) ? sanitize_text_field(wp_unslash($_GET['title_filter'])) : '';
 		$location_filter = isset($_GET['location_filter']) ? sanitize_text_field(wp_unslash($_GET['location_filter'])) : '';
 		$type_filter = isset($_GET['type_filter']) ? sanitize_text_field(wp_unslash($_GET['type_filter'])) : '';
 		$category_filter = isset($_GET['category_filter']) ? sanitize_text_field(wp_unslash($_GET['category_filter'])) : '';
@@ -11,6 +12,11 @@
 		$duration_filter = isset($_GET['duration_filter']) ? sanitize_text_field(wp_unslash($_GET['duration_filter'])) : '';
 		$activity_filter = isset($_GET['activity_filter']) ? sanitize_text_field(wp_unslash($_GET['activity_filter'])) : '';
 		$month_filter = isset($_GET['month_filter']) ? sanitize_text_field(wp_unslash($_GET['month_filter'])) : '';
+		if ($title_filter) {
+			?>
+            <input type="hidden" name="title_filter" value="<?php echo esc_attr($title_filter); ?>"/>
+			<?php
+		}
 		if ($location_filter) {
 			?>
             <input type="hidden" name="location_filter" value="<?php echo esc_attr($location_filter); ?>"/>

--- a/tour-booking-manager.php
+++ b/tour-booking-manager.php
@@ -54,6 +54,10 @@ if (!class_exists('TTBM_Woocommerce_Plugin')) {
 				if (is_network_admin() || isset($_GET['activate-multi']) || wp_doing_ajax()) {
 					return;
 				}
+				// Avoid interfering with REST requests (e.g., Gutenberg saves)
+				if (defined('REST_REQUEST') && REST_REQUEST) {
+					return;
+				}
 				
 				$ttbm_quick_setup_done = get_option('ttbm_quick_setup_done', 'no');
 				


### PR DESCRIPTION
- TTBM_Filter_Pagination: Change nonce verification from \ to \ (search form uses method='get', so all form data is in \)
- TTBM_Tour_List: Fix nonce check for filter data attributes on tour items (enables client-side filtering by title, organizer, etc.)
- filter_hidden: Add title_filter support for preserving search state on results page

The title-filter, organizer-filter and other shortcode options now work correctly when using [ttbm-top-search title-filter='yes' organizer-filter='no']