### PR TITLE
Fix undefined array key warning in WooCommerce integration: Handle 

### DIFF
--- a/inc/TTBM_Woocommerce.php
+++ b/inc/TTBM_Woocommerce.php
@@ -597,10 +597,10 @@
 					$ttbm_hotel_num_of_day = isset($_POST['ttbm_hotel_num_of_day']) ? sanitize_text_field(wp_unslash($_POST['ttbm_hotel_num_of_day'])) : 0;
 					$count = count($names);
 					if (sizeof($names) > 0) {
-						for ($i = 0; $i < $count; $i++) {
+						foreach ($names as $i => $name) {
 							if (isset($qty[$i]) && $qty[$i] > 0) {
 								$total_qty = $total_qty + $qty[$i];
-								$price = TTBM_Function::get_price_by_name($names[$i], $tour_id, $hotel_id, $qty[$i], $start_date) * $qty[$i];
+								$price = TTBM_Function::get_price_by_name($name, $tour_id, $hotel_id, $qty[$i], $start_date) * $qty[$i];
 								if ($hotel_id > 0) {
 									$price = $price * $ttbm_hotel_num_of_day;
 								}

--- a/templates/ticket/regular_ticket.php
+++ b/templates/ticket/regular_ticket.php
@@ -157,11 +157,11 @@ if (!defined('ABSPATH')) {
 								<tr class="ttbm_hidden_inputs">
 									<td colspan="<?php echo $hide_availability_column === 'on' ? '3' : '4'; ?>">
 										<?php do_action('ttbm_input_data',$ticket_name,$tour_id); ?>
-										<input type="hidden" name='tour_id[]' value='<?php echo esc_html($tour_id); ?>'>
-										<input type="hidden" name='ticket_name[]' value='<?php echo esc_html($ticket_name); ?>'>
-										<input type="hidden" name='ticket_max_qty[]' value='<?php echo esc_html($max_qty); ?>'>
-										<input type="hidden" name='ticket_available_qty[]' value='<?php echo esc_html($available); ?>'>
-										<input type="hidden" name='ticket_capacity[]' value='<?php echo esc_html($total_capacity); ?>'>
+										<input type="hidden" name='tour_id[<?php echo $index; ?>]' value='<?php echo esc_html($tour_id); ?>'>
+										<input type="hidden" name='ticket_name[<?php echo $index; ?>]' value='<?php echo esc_html($ticket_name); ?>'>
+										<input type="hidden" name='ticket_max_qty[<?php echo $index; ?>]' value='<?php echo esc_html($max_qty); ?>'>
+										<input type="hidden" name='ticket_available_qty[<?php echo $index; ?>]' value='<?php echo esc_html($available); ?>'>
+										<input type="hidden" name='ticket_capacity[<?php echo $index; ?>]' value='<?php echo esc_html($total_capacity); ?>'>
 									</td>
 								</tr>
 								<?php do_action('ttbm_after_ticket_type_item', $tour_id, $ticket); ?>


### PR DESCRIPTION
sp…arse arrays in ticket quantity submission, use explicit indices for hidden inputs in regular_ticket.php, and iterate over keys in TTBM_Woocommerce.php using foreach loop.