### PR TITLE
﻿fix(security): harden admin access, booking integrity, and internal …

### DIFF
--- a/admin/TTBM_Admin_Tour_List.php
+++ b/admin/TTBM_Admin_Tour_List.php
@@ -17,6 +17,10 @@
 
             }
 
+            private function user_can_manage_tours() {
+                return current_user_can('manage_options');
+            }
+
             public function remove_default_menu(){
                 remove_submenu_page('edit.php?post_type=ttbm_tour', 'edit.php?post_type=ttbm_tour');
                 remove_submenu_page('edit.php?post_type=ttbm_tour', 'post-new.php?post_type=ttbm_tour');
@@ -29,6 +33,9 @@
 		            wp_send_json_error( [ 'message' => 'Invalid nonce' ] );
 		            die;
 	            }
+                if (!$this->user_can_manage_tours()) {
+                    wp_send_json_error(['message' => esc_html__('You do not have permission to view tour data.', 'tour-booking-manager')], 403);
+                }
                 $paged = isset($_POST['paged']) ? intval(wp_unslash($_POST['paged'])) : 1;
                 $post_per_page = isset($_POST['post_per_page']) ? intval(wp_unslash($_POST['post_per_page'])) : 10;
                 $search = isset($_POST['search_term']) ? sanitize_text_field(wp_unslash($_POST['search_term'])) : '';
@@ -63,6 +70,10 @@
 
             public  function load_more_callback() {
                 check_ajax_referer('ttbm_load_more', 'nonce');
+
+                if (!$this->user_can_manage_tours()) {
+                    wp_send_json_error(['message' => esc_html__('You do not have permission to view tour data.', 'tour-booking-manager')], 403);
+                }
             
                 $paged = isset($_POST['paged']) ? intval($_POST['paged']) : 1;
                 $post_per_page = isset($_POST['post_per_page']) ? intval($_POST['post_per_page']) : 10;

--- a/admin/TTBM_CPT.php
+++ b/admin/TTBM_CPT.php
@@ -132,10 +132,14 @@ register_post_type('ttbm_hotel', $args);
 						'name' => __('Hotel Bookings', 'tour-booking-manager'),
                         'singular_name' => __('Hotel Booking', 'tour-booking-manager'),
                     ),
-                    'public' => true,
-                    'has_archive' => true,
+                    'public' => false,
+                    'publicly_queryable' => false,
+                    'has_archive' => false,
                     'show_ui' => false,
-                    'show_in_menu' => true, // Ensure it's visible in the admin menu
+                    'show_in_menu' => false,
+                    'exclude_from_search' => true,
+                    'rewrite' => false,
+                    'map_meta_cap' => true,
                     'supports' => array('title', 'editor', 'custom-fields'),
                 ));
 

--- a/admin/TTBM_Get_Enquiry.php
+++ b/admin/TTBM_Get_Enquiry.php
@@ -25,15 +25,40 @@ if (! class_exists('TTBM_Get_Enquiry')) {
             add_action('wp_ajax_ttbm_reply_enquiry', [$this, 'reply_enquiry']);
         }
 
+        private function user_can_manage_enquiries() {
+            return current_user_can('manage_options');
+        }
+
+        private function get_authorized_enquiry($enquiry_id, $delete = false) {
+            if (!$this->user_can_manage_enquiries()) {
+                wp_send_json_error(['message' => __('You do not have permission to access enquiries.', 'tour-booking-manager')], 403);
+            }
+
+            $post = get_post($enquiry_id);
+            if (!$post || $post->post_type !== 'ttbm_enquiry') {
+                wp_send_json_error(['message' => __('Enquiry not found.', 'tour-booking-manager')], 404);
+            }
+
+            if ($delete && !current_user_can('delete_post', $enquiry_id)) {
+                wp_send_json_error(['message' => __('You do not have permission to delete this enquiry.', 'tour-booking-manager')], 403);
+            }
+
+            if (!$delete && !current_user_can('edit_post', $enquiry_id)) {
+                wp_send_json_error(['message' => __('You do not have permission to access this enquiry.', 'tour-booking-manager')], 403);
+            }
+
+            return $post;
+        }
+
         public function view_enquiry(){
 	        if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field(wp_unslash($_POST['nonce'] )), 'ttbm_admin_nonce' ) ) {
 		        wp_send_json_error( [ 'message' => 'Invalid nonce' ] );
 		        die;
 	        }
-	        $enquiry_id = isset($_POST['enquiry_id']) ? intval(wp_unslash($_POST['enquiry_id'] )): '';
-            $post = get_post($enquiry_id);
+	        $enquiry_id = isset($_POST['enquiry_id']) ? absint(wp_unslash($_POST['enquiry_id'] )) : 0;
+            $post = $this->get_authorized_enquiry($enquiry_id);
 
-            if ($post && $post->post_type === 'ttbm_enquiry') {
+            if ($post) {
                 $response = [
                     'title'   => esc_html($post->post_title),
                     'content' => wpautop(wp_kses_post($post->post_content)),
@@ -84,9 +109,9 @@ if (! class_exists('TTBM_Get_Enquiry')) {
 		        wp_send_json_error( [ 'message' => 'Invalid nonce' ] );
 		        die;
 	        }
-	        $enquiry_id = isset($_POST['enquiry_id']) ? intval(wp_unslash($_POST['enquiry_id'] )): '';
-            $post = get_post($enquiry_id);
-            if ($post && $post->post_type === 'ttbm_enquiry' && wp_delete_post($enquiry_id, true)) {
+	        $enquiry_id = isset($_POST['enquiry_id']) ? absint(wp_unslash($_POST['enquiry_id'] )) : 0;
+            $post = $this->get_authorized_enquiry($enquiry_id, true);
+            if ($post && wp_delete_post($enquiry_id, true)) {
                 wp_send_json_success(['message' => __('Enquiry deleted successfully.', 'tour-booking-manager')]);
             } else {
                 wp_send_json_error(['message' => __('Failed to delete enquiry. Please try again.', 'tour-booking-manager')]);
@@ -100,11 +125,16 @@ if (! class_exists('TTBM_Get_Enquiry')) {
             $form_data = [];
 	        $data = isset($_POST['data']) ? sanitize_text_field(wp_unslash($_POST['data'] )): '';
             parse_str($data, $form_data);
-            $postId=sanitize_text_field($form_data['ttbm_post_id'] ?? '');
+            $postId = isset($form_data['ttbm_post_id']) ? absint($form_data['ttbm_post_id']) : 0;
+            $this->get_authorized_enquiry($postId);
             $to = sanitize_email($form_data['ttbm-reply-to'] ?? '');
             $from = sanitize_email($form_data['ttbm-reply-from'] ?? '');
             $subject = sanitize_text_field($form_data['ttbm-reply-subject'] ?? '');
             $message = wp_kses_post($form_data['ttbm-reply-message'] ?? '');
+
+            if (!is_email($to) || empty($subject) || empty(wp_strip_all_tags($message))) {
+                wp_send_json_error(['message' => __('Please provide a valid recipient, subject, and message.', 'tour-booking-manager')]);
+            }
             
             // Get configured from email if not provided
             if (empty($from)) {
@@ -299,17 +329,18 @@ if (! class_exists('TTBM_Get_Enquiry')) {
 
             $args = [
                 'labels'             => $labels,
-                'public'             => true,
-                'publicly_queryable' => true,
+                'public'             => false,
+                'publicly_queryable' => false,
                 'show_ui'            => false,
-                'show_in_menu'       => true,
+                'show_in_menu'       => false,
                 'query_var'          => true,
-                'rewrite'            => ['slug' => 'ttbm_enquiry'],
+                'rewrite'            => false,
                 'capability_type'    => 'post',
-                'has_archive'        => true,
+                'has_archive'        => false,
                 'hierarchical'       => false,
                 'menu_position'      => null,
                 'supports'           => ['title', 'editor', 'custom-fields'],
+                'exclude_from_search'=> true,
                 'capabilities'       => [
                     'create_posts' => 'do_not_allow',
                 ],

--- a/admin/settings/hotel/TTBM_Settings_Hotel.php
+++ b/admin/settings/hotel/TTBM_Settings_Hotel.php
@@ -54,7 +54,13 @@
 				<?php
 			}
 			public function save_hotel($post_id) {
-				if (!isset($_POST['ttbm_hotel_type_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_hotel_type_nonce'])), 'ttbm_hotel_type_nonce') && defined('DOING_AUTOSAVE') && DOING_AUTOSAVE && !current_user_can('edit_post', $post_id)) {
+				if (!isset($_POST['ttbm_hotel_type_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_hotel_type_nonce'])), 'ttbm_hotel_type_nonce')) {
+					return;
+				}
+				if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+					return;
+				}
+				if (!current_user_can('edit_post', $post_id)) {
 					return;
 				}
 				if (get_post_type($post_id) == 'ttbm_hotel') {

--- a/admin/settings/hotel/TTBM_Settings_Hotel_Activity.php
+++ b/admin/settings/hotel/TTBM_Settings_Hotel_Activity.php
@@ -111,7 +111,13 @@
 			}
 
 			public function features_save($post_id){
-				if (!isset($_POST['ttbm_hotel_type_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_hotel_type_nonce'])), 'ttbm_hotel_type_nonce') && defined('DOING_AUTOSAVE') && DOING_AUTOSAVE && !current_user_can('edit_post', $post_id)) {
+				if (!isset($_POST['ttbm_hotel_type_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_hotel_type_nonce'])), 'ttbm_hotel_type_nonce')) {
+					return;
+				}
+				if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+					return;
+				}
+				if (!current_user_can('edit_post', $post_id)) {
 					return;
 				}
 				if (get_post_type($post_id) == 'ttbm_hotel') {

--- a/admin/settings/hotel/TTBM_Settings_Hotel_Ajax.php
+++ b/admin/settings/hotel/TTBM_Settings_Hotel_Ajax.php
@@ -19,11 +19,18 @@ if (!class_exists('TTBM_Settings_Hotel_Ajax')) {
             add_action('wp_ajax_nopriv_ttbm_load_more_hotel_lists_admin', [$this, 'ttbm_load_more_hotel_lists_admin']);
         }
 
+        private function user_can_manage_hotel_admin() {
+            return current_user_can('manage_options');
+        }
+
         public function get_ttbm_hotel_search_by_title() {
 	        if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field(wp_unslash($_POST['nonce'] )), 'ttbm_admin_nonce' ) ) {
 		        wp_send_json_error( [ 'message' => 'Invalid nonce' ] );
 		        die;
 	        }
+            if (!$this->user_can_manage_hotel_admin()) {
+                wp_send_json_error(['message' => esc_html__('You do not have permission to view hotel data.', 'tour-booking-manager')], 403);
+            }
             $search_term = isset( $_POST['search_term'] ) ? sanitize_text_field( wp_unslash( $_POST['search_term'] ) ) : '';
             $display_limit = 20;
             $success = false;
@@ -63,6 +70,9 @@ if (!class_exists('TTBM_Settings_Hotel_Ajax')) {
             $result = $post_count = $found_posts = 0;
             $result_data = '';
             $message = 'Something went wrong';
+            if (!$this->user_can_manage_hotel_admin()) {
+                wp_send_json_error(['message' => esc_html__('You do not have permission to view booking data.', 'tour-booking-manager')], 403);
+            }
             if( isset( $_POST ) ){
                 if( isset( $_POST['action'] ) &&sanitize_text_field(wp_unslash($_POST['action'] ))== 'get_ttbm_hotel_booking_all_lists' ){
                     if (isset($_POST['nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'ttbm_admin_nonce')) {
@@ -99,6 +109,9 @@ if (!class_exists('TTBM_Settings_Hotel_Ajax')) {
             $result = $post_count = $found_posts = 0;
             $result_data = '';
             $message = 'Something went wrong';
+            if (!$this->user_can_manage_hotel_admin()) {
+                wp_send_json_error(['message' => esc_html__('You do not have permission to view booking data.', 'tour-booking-manager')], 403);
+            }
             if( isset( $_POST ) ){
                 if( isset( $_POST['action'] ) && sanitize_text_field(wp_unslash($_POST['action'] )) == 'get_ttbm_hotel_booking_load_more_lists' ){
                     if ( isset($_POST['nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'ttbm_admin_nonce')) {
@@ -134,6 +147,9 @@ if (!class_exists('TTBM_Settings_Hotel_Ajax')) {
             $result = $post_count = $found_posts = 0;
             $result_data = '';
             $message = 'Something went wrong';
+            if (!$this->user_can_manage_hotel_admin()) {
+                wp_send_json_error(['message' => esc_html__('You do not have permission to view hotel data.', 'tour-booking-manager')], 403);
+            }
             if( isset( $_POST ) ){
                 if( isset( $_POST['action'] ) && sanitize_text_field(wp_unslash($_POST['action'] ))== 'ttbm_load_more_hotel_lists_admin' ){
 

--- a/admin/settings/hotel/TTBM_Settings_Hotel_Area_Info.php
+++ b/admin/settings/hotel/TTBM_Settings_Hotel_Area_Info.php
@@ -174,7 +174,13 @@
 			 * Save hotel area info data on post save
 			 */
 			public function save_hotel_area_info($post_id) {
-				if (!isset($_POST['ttbm_hotel_type_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_hotel_type_nonce'])), 'ttbm_hotel_type_nonce') && defined('DOING_AUTOSAVE') && DOING_AUTOSAVE && !current_user_can('edit_post', $post_id)) {
+				if (!isset($_POST['ttbm_hotel_type_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_hotel_type_nonce'])), 'ttbm_hotel_type_nonce')) {
+					return;
+				}
+				if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+					return;
+				}
+				if (!current_user_can('edit_post', $post_id)) {
 					return;
 				}
 

--- a/admin/settings/hotel/TTBM_Settings_Hotel_FAQ.php
+++ b/admin/settings/hotel/TTBM_Settings_Hotel_FAQ.php
@@ -24,6 +24,10 @@
 				add_action('wp_ajax_ttbm_hotel_ttbm_faq_sort', [$this, 'sort_faq']);
 			}
 
+			private function current_user_can_edit_hotel($post_id) {
+				return $post_id > 0 && current_user_can('edit_post', $post_id);
+			}
+
 			public function my_custom_editor_enqueue() {
 				// Enqueue necessary scripts
 				wp_enqueue_script('jquery');
@@ -132,7 +136,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'ttbm_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['ttbm_faq_postID']) ? sanitize_text_field(wp_unslash($_POST['ttbm_faq_postID'])) : '';
+				$post_id = isset($_POST['ttbm_faq_postID']) ? absint(wp_unslash($_POST['ttbm_faq_postID'])) : 0;
+				if (!$this->current_user_can_edit_hotel($post_id)) {
+					wp_send_json_error('Permission denied!', 403);
+				}
 				$ttbm_hotel_faq_title = isset($_POST['ttbm_hotel_faq_title']) ? sanitize_text_field(wp_unslash($_POST['ttbm_hotel_faq_title'])) : '';
 				$ttbm_hotel_faq_content = isset($_POST['ttbm_hotel_faq_content']) ? wp_kses_post(wp_unslash($_POST['ttbm_hotel_faq_content'])) : '';
 				$ttbm_faq = get_post_meta($post_id, 'ttbm_hotel_faq', true);
@@ -160,7 +167,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'ttbm_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['ttbm_faq_postID']) ? sanitize_text_field(wp_unslash($_POST['ttbm_faq_postID'])) : '';
+				$post_id = isset($_POST['ttbm_faq_postID']) ? absint(wp_unslash($_POST['ttbm_faq_postID'])) : 0;
+				if (!$this->current_user_can_edit_hotel($post_id)) {
+					wp_send_json_error('Permission denied!', 403);
+				}
 				update_post_meta($post_id, 'ttbm_hotel_faq_status', 'on');
 				$ttbm_hotel_faq_title = isset($_POST['ttbm_hotel_faq_title']) ? sanitize_text_field(wp_unslash($_POST['ttbm_hotel_faq_title'])) : '';
 				$ttbm_hotel_faq_content = isset($_POST['ttbm_hotel_faq_content']) ? wp_kses_post(wp_unslash($_POST['ttbm_hotel_faq_content'])) : '';
@@ -193,7 +203,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'ttbm_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['ttbm_faq_postID']) ? sanitize_text_field(wp_unslash($_POST['ttbm_faq_postID'])) : '';
+				$post_id = isset($_POST['ttbm_faq_postID']) ? absint(wp_unslash($_POST['ttbm_faq_postID'])) : 0;
+				if (!$this->current_user_can_edit_hotel($post_id)) {
+					wp_send_json_error('Permission denied!', 403);
+				}
 				$ttbm_faq = get_post_meta($post_id, 'ttbm_hotel_faq', true);
 				$ttbm_faq = !empty($ttbm_faq) ? $ttbm_faq : [];
 				if (!empty($ttbm_faq)) {
@@ -225,8 +238,11 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'ttbm_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['postID']) ? sanitize_text_field(wp_unslash($_POST['postID'])) : '';
-				$sorted_ids = isset($_POST['sortedIDs']) ? array_map('intval', $_POST['sortedIDs']) : [];
+				$post_id = isset($_POST['postID']) ? absint(wp_unslash($_POST['postID'])) : 0;
+				if (!$this->current_user_can_edit_hotel($post_id)) {
+					wp_send_json_error('Permission denied!', 403);
+				}
+				$sorted_ids = isset($_POST['sortedIDs']) ? array_map('absint', (array) wp_unslash($_POST['sortedIDs'])) : [];
 				$ttbm_faq = get_post_meta($post_id, 'ttbm_hotel_faq', true);;
 				$new_ordered = [];
 				foreach ($sorted_ids as $id) {

--- a/admin/settings/hotel/TTBM_Settings_Hotel_Feature.php
+++ b/admin/settings/hotel/TTBM_Settings_Hotel_Feature.php
@@ -152,7 +152,13 @@
 			}
 
 			public function features_save($post_id){
-				if (!isset($_POST['ttbm_hotel_type_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_hotel_type_nonce'])), 'ttbm_hotel_type_nonce') && defined('DOING_AUTOSAVE') && DOING_AUTOSAVE && !current_user_can('edit_post', $post_id)) {
+				if (!isset($_POST['ttbm_hotel_type_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_hotel_type_nonce'])), 'ttbm_hotel_type_nonce')) {
+					return;
+				}
+				if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+					return;
+				}
+				if (!current_user_can('edit_post', $post_id)) {
 					return;
 				}
 				if (get_post_type($post_id) == 'ttbm_hotel') {

--- a/admin/settings/hotel/dashboard/TTBM_Hotel_Activities.php
+++ b/admin/settings/hotel/dashboard/TTBM_Hotel_Activities.php
@@ -15,6 +15,9 @@ if (!class_exists('TTBM_Hotel_Activities')) {
             // ttbm_delete_faq_data
 			add_action('wp_ajax_ttbm_hotel_activity_delete', [$this, 'activity_delete_item']);
         }
+        private function user_can_manage_hotel_activities() {
+            return current_user_can('manage_options');
+        }
         public function dashbaord_activity(){
             ?>
             <div class="ttbm_hotel_tab_item" data-tab="ttbm_hotel_activities_tab"><i class="mi mi-practice"></i> <?php echo esc_attr__( 'Hotel Activities', 'tour-booking-manager' )?></div>
@@ -120,6 +123,9 @@ if (!class_exists('TTBM_Hotel_Activities')) {
             if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'ttbm_admin_nonce')) {
                 wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
             }
+            if (!$this->user_can_manage_hotel_activities()) {
+                wp_send_json_error('Permission denied!', 403);
+            }
             $feature_title = isset($_POST['ttbm_hotel_activity_title']) ? sanitize_text_field(wp_unslash($_POST['ttbm_hotel_activity_title'])) : '';
             $feature_slug = isset($_POST['ttbm_hotel_activity_slug']) ? sanitize_title(wp_unslash($_POST['ttbm_hotel_activity_slug'])) : '';
             $feature_icon = isset($_POST['ttbm_hotel_activity_icon']) ? sanitize_text_field(wp_unslash($_POST['ttbm_hotel_activity_icon'])) : '';
@@ -173,6 +179,9 @@ if (!class_exists('TTBM_Hotel_Activities')) {
             if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'ttbm_admin_nonce')) {
                 wp_send_json_error('Invalid nonce!');
             }
+            if (!$this->user_can_manage_hotel_activities()) {
+                wp_send_json_error('Permission denied!', 403);
+            }
 
             $feature_id = isset($_POST['ttbm_hotel_activity_id']) ? intval($_POST['ttbm_hotel_activity_id']) : 0;
             $feature_title = isset($_POST['ttbm_hotel_activity_title']) ? sanitize_text_field(wp_unslash($_POST['ttbm_hotel_activity_title'])) : '';
@@ -209,6 +218,9 @@ if (!class_exists('TTBM_Hotel_Activities')) {
             // Check nonce for security
             if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'ttbm_admin_nonce')) {
                 wp_send_json_error('Invalid nonce!');
+            }
+            if (!$this->user_can_manage_hotel_activities()) {
+                wp_send_json_error('Permission denied!', 403);
             }
 
             $item_id = isset($_POST['itemId']) ? intval($_POST['itemId']) : 0;

--- a/admin/settings/hotel/dashboard/TTBM_Hotel_Features.php
+++ b/admin/settings/hotel/dashboard/TTBM_Hotel_Features.php
@@ -14,7 +14,11 @@ if (!class_exists('TTBM_Hotel_Features')) {
             // ttbm_update_faq_data
 			add_action('wp_ajax_ttbm_hotel_feature_update', [$this, 'feature_update_item']);
             // ttbm_delete_faq_data
-			add_action('wp_ajax_ttbm_hotel_feature_delete', [$this, 'feature_delete_item']);
+            add_action('wp_ajax_ttbm_hotel_feature_delete', [$this, 'feature_delete_item']);
+        }
+
+        private function user_can_manage_hotel_features() {
+            return current_user_can('manage_options');
         }
 
         public function dashbaord_features(){
@@ -123,6 +127,9 @@ if (!class_exists('TTBM_Hotel_Features')) {
             if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'ttbm_admin_nonce')) {
                 wp_send_json_error('Invalid nonce!');
             }
+            if (!$this->user_can_manage_hotel_features()) {
+                wp_send_json_error('Permission denied!', 403);
+            }
 
             $item_id = isset($_POST['itemId']) ? intval($_POST['itemId']) : 0;
 
@@ -152,6 +159,9 @@ if (!class_exists('TTBM_Hotel_Features')) {
         public function feature_update_item() {
             if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'ttbm_admin_nonce')) {
                 wp_send_json_error('Invalid nonce!');
+            }
+            if (!$this->user_can_manage_hotel_features()) {
+                wp_send_json_error('Permission denied!', 403);
             }
 
             $feature_id = isset($_POST['ttbm_hotel_feature_id']) ? intval($_POST['ttbm_hotel_feature_id']) : 0;
@@ -187,6 +197,9 @@ if (!class_exists('TTBM_Hotel_Features')) {
         public function hotel_feature_save() {	
             if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'ttbm_admin_nonce')) {
                 wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
+            }
+            if (!$this->user_can_manage_hotel_features()) {
+                wp_send_json_error('Permission denied!', 403);
             }
             $feature_title = isset($_POST['ttbm_hotel_feature_title']) ? sanitize_text_field(wp_unslash($_POST['ttbm_hotel_feature_title'])) : '';
             $feature_slug = isset($_POST['ttbm_hotel_feature_slug']) ? sanitize_title(wp_unslash($_POST['ttbm_hotel_feature_slug'])) : '';

--- a/admin/settings/tour/TTBM_Settings.php
+++ b/admin/settings/tour/TTBM_Settings.php
@@ -240,8 +240,14 @@
 			//********************//
 			public function save_settings($tour_id) {
 				//echo '<pre>';print_r($_POST);echo '</pre>';die();
-				if (!isset($_POST['ttbm_ticket_type_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_ticket_type_nonce'])), 'ttbm_ticket_type_nonce') && defined('DOING_AUTOSAVE') && DOING_AUTOSAVE && !current_user_can('edit_post', $tour_id)) {
+				if (!isset($_POST['ttbm_ticket_type_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_ticket_type_nonce'])), 'ttbm_ticket_type_nonce')) {
 					//echo '<pre>';print_r($_POST['ttbm_ticket_type_nonce']);echo '</pre>';die();
+					return;
+				}
+				if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+					return;
+				}
+				if (!current_user_can('edit_post', $tour_id)) {
 					return;
 				}
 				//echo '<pre>';print_r($_POST);echo '</pre>';die();

--- a/admin/settings/tour/TTBM_Settings_Dates.php
+++ b/admin/settings/tour/TTBM_Settings_Dates.php
@@ -277,7 +277,7 @@
 										<?php
 											$off_day_array = TTBM_Global_Function::get_post_info($tour_id, 'mep_ticket_offdays');
 											if (!is_array($off_day_array)) {
-												$maybe_unserialized = @unserialize($off_day_array);
+												$maybe_unserialized = @unserialize($off_day_array, ['allowed_classes' => false]);
 												if (is_array($maybe_unserialized)) {
 													$off_day_array = $maybe_unserialized;
 												} else {

--- a/admin/settings/tour/TTBM_Settings_Feature.php
+++ b/admin/settings/tour/TTBM_Settings_Feature.php
@@ -16,6 +16,12 @@
 				add_action('wp_ajax_ttbm_new_feature_save', [$this, 'ttbm_new_feature_save']);
 				add_action('wp_ajax_nopriv_ttbm_new_feature_save', [$this, 'ttbm_new_feature_save']);
 			}
+			private function current_user_can_manage_feature_terms() {
+				return current_user_can('manage_options');
+			}
+			private function current_user_can_edit_tour($tour_id) {
+				return $tour_id > 0 && current_user_can('edit_post', $tour_id);
+			}
 			public function ttbm_settings_feature($tour_id) {
 				?>
                 <div class="tabsItem ttbm_settings_feature" data-tabs="#ttbm_settings_feature">
@@ -106,6 +112,9 @@
 				<?php
 			}
 			public function load_ttbm_feature_form() {
+				if (!$this->current_user_can_manage_feature_terms()) {
+					wp_die(esc_html__('You do not have permission to access this form.', 'tour-booking-manager'), '', ['response' => 403]);
+				}
 				wp_nonce_field('ttbm_add_new_feature_popup', 'ttbm_add_new_feature_popup');
 				?>
                 <label class="flexEqual">
@@ -138,7 +147,10 @@
 					wp_send_json_error(['message' => 'Invalid nonce']);
 					die;
 				}
-				$ttbm_id = isset($_POST['ttbm_id']) ? sanitize_text_field(wp_unslash($_POST['ttbm_id'])) : 0;
+				$ttbm_id = isset($_POST['ttbm_id']) ? absint(wp_unslash($_POST['ttbm_id'])) : 0;
+				if (!$this->current_user_can_edit_tour($ttbm_id)) {
+					wp_send_json_error(['message' => esc_html__('You do not have permission to access this tour.', 'tour-booking-manager')], 403);
+				}
 				// Load the included and excluded features sections
 				ob_start();
 				$this->feature($ttbm_id);

--- a/admin/settings/tour/TTBM_Settings_Location.php
+++ b/admin/settings/tour/TTBM_Settings_Location.php
@@ -25,6 +25,12 @@
 				add_action('ttbm_hiphop_place_map', [$this, 'show_map_frontend']);
 				add_action('ttbm_common_script', [$this, 'osmap_script']);
 			}
+			private function current_user_can_manage_locations() {
+				return current_user_can('manage_options');
+			}
+			private function current_user_can_edit_location_post($post_id) {
+				return $post_id > 0 && current_user_can('edit_post', $post_id);
+			}
 			public function osmap_script() {
 				//openstreet map css
 				wp_enqueue_style('ttbm_leaflet_style', TTBM_PLUGIN_URL . '/assets/osmap/leaflet.css', array(), time());
@@ -156,6 +162,9 @@
 				<?php
 			}
 			public function load_ttbm_location_form() {
+				if (!$this->current_user_can_manage_locations()) {
+					wp_die(esc_html__('You do not have permission to access this form.', 'tour-booking-manager'), '', ['response' => 403]);
+				}
 				$all_countries = ttbm_get_coutnry_arr();
 				?>
                 <label class="flexEqual">
@@ -207,7 +216,10 @@
 					wp_send_json_error(['message' => 'Invalid nonce']);
 					die;
 				}
-				$ttbm_id = isset($_POST['ttbm_id']) ? sanitize_text_field(wp_unslash($_POST['ttbm_id'])) : 0;
+				$ttbm_id = isset($_POST['ttbm_id']) ? absint(wp_unslash($_POST['ttbm_id'])) : 0;
+				if (!$this->current_user_can_edit_location_post($ttbm_id)) {
+					wp_send_json_error(['message' => esc_html__('You do not have permission to access this location.', 'tour-booking-manager')], 403);
+				}
 				self::location_select($ttbm_id);
 				die();
 			}
@@ -295,6 +307,9 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'ttbm_admin_nonce')) {
 					wp_send_json_error(['message' => 'Invalid nonce']);
 					die;
+				}
+				if (!$this->current_user_can_manage_locations()) {
+					wp_send_json_error(['message' => esc_html__('You do not have permission to create locations.', 'tour-booking-manager')], 403);
 				}
 				$name = isset($_POST['name']) ? sanitize_text_field(wp_unslash($_POST['name'])) : '';
 				$description = isset($_POST['description']) ? sanitize_text_field(wp_unslash($_POST['description'])) : '';

--- a/admin/settings/tour/TTBM_Settings_activity.php
+++ b/admin/settings/tour/TTBM_Settings_activity.php
@@ -15,6 +15,12 @@
 				add_action('wp_ajax_ttbm_new_activity_save', [$this, 'ttbm_new_activity_save']);
 				add_action('wp_ajax_nopriv_ttbm_new_activity_save', [$this, 'ttbm_new_activity_save']);
 			}
+			private function current_user_can_manage_activity_terms() {
+				return current_user_can('manage_options');
+			}
+			private function current_user_can_edit_tour($tour_id) {
+				return $tour_id > 0 && current_user_can('edit_post', $tour_id);
+			}
 			public function ttbm_settings_activities($tour_id) {
 				$display = TTBM_Global_Function::get_post_info($tour_id, 'ttbm_display_activities', 'on');
 				$active = $display == 'off' ? '' : 'mActive';
@@ -90,6 +96,9 @@
 				<?php
 			}
 			public function load_ttbm_activity_form() {
+				if (!$this->current_user_can_manage_activity_terms()) {
+					wp_die(esc_html__('You do not have permission to access this form.', 'tour-booking-manager'), '', ['response' => 403]);
+				}
 				wp_nonce_field('ttbm_add_new_activity_popup', 'ttbm_add_new_activity_popup');
 				?>
                 <label class="flexEqual">
@@ -122,7 +131,10 @@
 					wp_send_json_error(['message' => 'Invalid nonce']);
 					die;
 				}
-				$ttbm_id = isset($_POST['ttbm_id']) ? sanitize_text_field(wp_unslash($_POST['ttbm_id'])) : 0;
+				$ttbm_id = isset($_POST['ttbm_id']) ? absint(wp_unslash($_POST['ttbm_id'])) : 0;
+				if (!$this->current_user_can_edit_tour($ttbm_id)) {
+					wp_send_json_error(['message' => esc_html__('You do not have permission to access this tour.', 'tour-booking-manager')], 403);
+				}
 				$this->activities($ttbm_id);
 				die();
 			}

--- a/admin/settings/tour/TTBM_Settings_faq.php
+++ b/admin/settings/tour/TTBM_Settings_faq.php
@@ -25,12 +25,18 @@
 				// FAQ sort_faq
 				add_action('wp_ajax_ttbm_sort_faq', [$this, 'sort_faq']);
 			}
+			private function current_user_can_edit_faq_post($post_id) {
+				return $post_id > 0 && current_user_can('edit_post', $post_id);
+			}
 			public function sort_faq() {
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'ttbm_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['postID']) ? sanitize_text_field(wp_unslash($_POST['postID'])) : '';
-				$sorted_ids = isset($_POST['sortedIDs']) ? array_map('intval', $_POST['sortedIDs']) : [];
+				$post_id = isset($_POST['postID']) ? absint(wp_unslash($_POST['postID'])) : 0;
+				if (!$this->current_user_can_edit_faq_post($post_id)) {
+					wp_send_json_error('Permission denied!', 403);
+				}
+				$sorted_ids = isset($_POST['sortedIDs']) ? array_map('absint', (array) wp_unslash($_POST['sortedIDs'])) : [];
 				$ttbm_faq = get_post_meta($post_id, 'mep_event_faq', true);
 				$new_ordered = [];
 				foreach ($sorted_ids as $id) {
@@ -151,7 +157,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'ttbm_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['ttbm_faq_postID']) ? sanitize_text_field(wp_unslash($_POST['ttbm_faq_postID'])) : '';
+				$post_id = isset($_POST['ttbm_faq_postID']) ? absint(wp_unslash($_POST['ttbm_faq_postID'])) : 0;
+				if (!$this->current_user_can_edit_faq_post($post_id)) {
+					wp_send_json_error('Permission denied!', 403);
+				}
 				$ttbm_faq_title = isset($_POST['ttbm_faq_title']) ? sanitize_text_field(wp_unslash($_POST['ttbm_faq_title'])) : '';
 				$allowed_tags = wp_kses_allowed_html('post');
 				$ttbm_faq_content = isset($_POST['ttbm_faq_content']) ? wp_kses(wp_unslash($_POST['ttbm_faq_content']), $allowed_tags) : '';
@@ -178,7 +187,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'ttbm_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['ttbm_faq_postID']) ? sanitize_text_field(wp_unslash($_POST['ttbm_faq_postID'])) : '';
+				$post_id = isset($_POST['ttbm_faq_postID']) ? absint(wp_unslash($_POST['ttbm_faq_postID'])) : 0;
+				if (!$this->current_user_can_edit_faq_post($post_id)) {
+					wp_send_json_error('Permission denied!', 403);
+				}
 				update_post_meta($post_id, 'ttbm_faq_active', 'on');
 				$ttbm_faq_title = isset($_POST['ttbm_faq_title']) ? sanitize_text_field(wp_unslash($_POST['ttbm_faq_title'])) : '';
 				$allowed_tags = wp_kses_allowed_html('post');
@@ -211,7 +223,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'ttbm_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['ttbm_faq_postID']) ? sanitize_text_field(wp_unslash($_POST['ttbm_faq_postID'])) : '';
+				$post_id = isset($_POST['ttbm_faq_postID']) ? absint(wp_unslash($_POST['ttbm_faq_postID'])) : 0;
+				if (!$this->current_user_can_edit_faq_post($post_id)) {
+					wp_send_json_error('Permission denied!', 403);
+				}
 				$ttbm_faq = get_post_meta($post_id, 'mep_event_faq', true);
 				$ttbm_faq = !empty($ttbm_faq) ? $ttbm_faq : [];
 				if (!empty($ttbm_faq)) {

--- a/admin/settings/tour/TTBM_Settings_place_you_see.php
+++ b/admin/settings/tour/TTBM_Settings_place_you_see.php
@@ -13,6 +13,9 @@
 				add_action('wp_ajax_nopriv_ttbm_reload_place_you_see_list', [$this, 'ttbm_reload_place_you_see_list']);
 				/******************************/
 			}
+			private function current_user_can_edit_tour($tour_id) {
+				return $tour_id > 0 && current_user_can('edit_post', $tour_id);
+			}
 			public function place_you_see_settings($tour_id) {
 				$display = TTBM_Global_Function::get_post_info($tour_id, 'ttbm_display_hiphop', 'on');
 				$active = $display == 'off' ? '' : 'mActive';
@@ -117,6 +120,9 @@
 				<?php
 			}
 			public function load_ttbm_place_you_see_form() {
+				if (!current_user_can('edit_posts')) {
+					wp_die(esc_html__('You do not have permission to access this form.', 'tour-booking-manager'), '', ['response' => 403]);
+				}
 				?>
                 <label class="flexEqual">
                     <span><?php esc_html_e('Place Name : ', 'tour-booking-manager'); ?><sup class="textRequired">*</sup></span> <input type="text" name="ttbm_place_name" class="formControl" required>
@@ -149,7 +155,10 @@
 					wp_send_json_error(['message' => 'Invalid nonce']);
 					die;
 				}
-				$ttbm_id = isset($_POST['ttbm_id']) ? sanitize_text_field(wp_unslash($_POST['ttbm_id'])) : 0;
+				$ttbm_id = isset($_POST['ttbm_id']) ? absint(wp_unslash($_POST['ttbm_id'])) : 0;
+				if (!$this->current_user_can_edit_tour($ttbm_id)) {
+					wp_send_json_error(['message' => esc_html__('You do not have permission to access this tour.', 'tour-booking-manager')], 403);
+				}
 				$this->place_you_see($ttbm_id);
 				die();
 			}

--- a/admin/settings/tour/TTBM_Settings_pricing.php
+++ b/admin/settings/tour/TTBM_Settings_pricing.php
@@ -10,6 +10,9 @@
 				add_action('wp_ajax_get_ttbm_insert_ticket_type', array($this, 'ticket_table'));
 				add_action('wp_ajax_nopriv_get_ttbm_insert_ticket_type', array($this, 'ticket_table'));
 			}
+			private function current_user_can_edit_ticket_context($post_id, $form_id) {
+				return $post_id > 0 && $form_id > 0 && current_user_can('edit_post', $post_id) && current_user_can('edit_post', $form_id);
+			}
 			public function pricing_tab_content($tour_id) {
 				$all_types = TTBM_Function::tour_type();
 				$ttbm_type = TTBM_Function::get_tour_type($tour_id);
@@ -144,8 +147,11 @@
 					wp_send_json_error(['message' => 'Invalid nonce']);
 					die;
 				}
-				$form_id = isset($_POST['form_id']) ? sanitize_text_field(wp_unslash($_POST['form_id'])) : '';
-				$post_id = isset($_POST['post_id']) ? sanitize_text_field(wp_unslash($_POST['post_id'])) : '';
+				$form_id = isset($_POST['form_id']) ? absint(wp_unslash($_POST['form_id'])) : 0;
+				$post_id = isset($_POST['post_id']) ? absint(wp_unslash($_POST['post_id'])) : 0;
+				if (!$this->current_user_can_edit_ticket_context($post_id, $form_id)) {
+					wp_send_json_error(['message' => esc_html__('You do not have permission to access this ticket configuration.', 'tour-booking-manager')], 403);
+				}
 				$ticket_type = TTBM_Global_Function::get_post_info($form_id, 'ttbm_ticket_type', array());
 				if (sizeof($ticket_type) > 0) {
 					foreach ($ticket_type as $field) {

--- a/inc/TTBM_Global_Function.php
+++ b/inc/TTBM_Global_Function.php
@@ -180,7 +180,7 @@
 			}
 			public static function data_sanitize($array) {
 				if (is_serialized($array)) {
-					$array = unserialize($array);
+					$array = @unserialize($array, ['allowed_classes' => false]);
 				}
 				if (is_string($array) && is_array(json_decode($array, true))) {
 					$array = json_decode($array, true);
@@ -837,7 +837,7 @@
 			//***********************************//
 			public static function data_sanitize($array) {
 				if (is_serialized($array)) {
-					$array = unserialize($array);
+					$array = @unserialize($array, ['allowed_classes' => false]);
 				}
 				if (is_string($array) && is_array(json_decode($array, true))) {
 					$array = json_decode($array, true);

--- a/inc/TTBM_Hotel_Booking.php
+++ b/inc/TTBM_Hotel_Booking.php
@@ -18,6 +18,79 @@
 				add_action('woocommerce_new_order', [$this, 'mptrs_woocommerce_new_order'], 10, 1);
 				add_action('woocommerce_order_status_changed', [$this, 'custom_function_on_order_status_change'], 10, 4);
 			}
+			private function parse_date_range($date_range) {
+				$date_parts = explode(' - ', (string) $date_range);
+				if (count($date_parts) !== 2) {
+					return false;
+				}
+
+				$check_in_timestamp = strtotime($date_parts[0]);
+				$check_out_timestamp = strtotime($date_parts[1]);
+				if ($check_in_timestamp === false || $check_out_timestamp === false || $check_out_timestamp <= $check_in_timestamp) {
+					return false;
+				}
+				$check_in = gmdate('Y-m-d', $check_in_timestamp);
+				$check_out = gmdate('Y-m-d', $check_out_timestamp);
+
+				$interval = date_create($check_in)->diff(date_create($check_out));
+				return [
+					'check_in' => $check_in,
+					'check_out' => $check_out,
+					'days' => (int) $interval->days,
+				];
+			}
+			private function build_hotel_booking_request($hotel_id, $date_range, $room_data_info) {
+				$date_info = $this->parse_date_range($date_range);
+				if (!$date_info || !is_array($room_data_info)) {
+					return new WP_Error('invalid_booking_request', __('Invalid booking request.', 'tour-booking-manager'));
+				}
+
+				$available_rooms = TTBM_Global_Function::ttbm_get_full_room_ticket_info($hotel_id, $date_info['check_in'], $date_info['check_out']);
+				$rooms_by_key = [];
+				foreach ($available_rooms as $room) {
+					$key = isset($room['room_type_key']) ? $room['room_type_key'] : preg_replace('/[^A-Za-z0-9]/', '', (string) ($room['ttbm_hotel_room_name'] ?? ''));
+					if ($key) {
+						$rooms_by_key[$key] = $room;
+					}
+				}
+
+				$sanitized_rooms = [];
+				$total_price = 0.0;
+				foreach ($room_data_info as $room_key => $room_request) {
+					$room_key = preg_replace('/[^A-Za-z0-9]/', '', (string) $room_key);
+					$quantity = isset($room_request['quantity']) ? absint($room_request['quantity']) : 0;
+					if (!$room_key || $quantity < 1) {
+						continue;
+					}
+					if (!isset($rooms_by_key[$room_key])) {
+						return new WP_Error('invalid_room', __('One or more selected rooms are invalid.', 'tour-booking-manager'));
+					}
+
+					$room = $rooms_by_key[$room_key];
+					$available = isset($room['available']) ? absint($room['available']) : 0;
+					if ($quantity > $available) {
+						return new WP_Error('room_unavailable', __('One or more selected rooms are no longer available.', 'tour-booking-manager'));
+					}
+
+					$nightly_price = isset($room['ttbm_hotel_room_price']) ? (float) $room['ttbm_hotel_room_price'] : 0.0;
+					$sanitized_rooms[$room_key] = [
+						'quantity' => $quantity,
+						'price' => $nightly_price,
+						'name' => $room['ttbm_hotel_room_name'] ?? $room_key,
+					];
+					$total_price += $nightly_price * $quantity * $date_info['days'];
+				}
+
+				if (empty($sanitized_rooms) || $total_price < 0) {
+					return new WP_Error('empty_booking', __('Please select at least one available room.', 'tour-booking-manager'));
+				}
+
+				return [
+					'rooms' => $sanitized_rooms,
+					'total_price' => $total_price,
+					'date_info' => $date_info,
+				];
+			}
 			function custom_function_on_order_status_change( $order_id, $old_status, $new_status, $order) {
 				if ($new_status === 'processing') {
 					$orderPostId = '';
@@ -139,7 +212,7 @@
 					wp_send_json_error(['message' => 'Invalid nonce']);
 					die;
 				}
-				$hotel_id = isset($_REQUEST['hotel_id']) ? sanitize_text_field(wp_unslash($_REQUEST['hotel_id'])) : '';
+				$hotel_id = isset($_REQUEST['hotel_id']) ? absint(wp_unslash($_REQUEST['hotel_id'])) : 0;
 				$date_range = isset($_REQUEST['date_range']) ? sanitize_text_field(wp_unslash($_REQUEST['date_range'])) : '';
 				$date = explode(" - ", $date_range);
 				$start_date = gmdate('Y-m-d', strtotime($date[0]));
@@ -153,37 +226,40 @@
 					die;
 				}
 
-				$hotel_id = isset($_REQUEST['hotel_id']) ? sanitize_text_field(wp_unslash($_REQUEST['hotel_id'])) : '';
+				$hotel_id = isset($_REQUEST['hotel_id']) ? absint(wp_unslash($_REQUEST['hotel_id'])) : 0;
 				$date_range = isset($_REQUEST['date_range']) ? sanitize_text_field(wp_unslash($_REQUEST['date_range'])) : '';
-				$room_data_info = isset($_REQUEST['room_data_info']) ? json_decode(sanitize_text_field(wp_unslash($_REQUEST['room_data_info'])), true) : [];
+				$room_data_info = isset($_REQUEST['room_data_info']) ? json_decode(wp_unslash($_REQUEST['room_data_info']), true) : [];
+				$booking_request = $this->build_hotel_booking_request($hotel_id, $date_range, $room_data_info);
+				if (is_wp_error($booking_request)) {
+					wp_send_json_error(['message' => $booking_request->get_error_message()]);
+				}
+
+				$room_data_info = $booking_request['rooms'];
+				$price = $booking_request['total_price'];
+				$check_in = $booking_request['date_info']['check_in'];
+				$check_out = $booking_request['date_info']['check_out'];
+				$days = $booking_request['date_info']['days'];
 				$room_output = "Room List\n\n";
 				$currency_symbol = get_woocommerce_currency_symbol();
 				$room_output .= '<div class="ttbm_hotel_ordered_room_list">';
 				foreach ($room_data_info as $roomName => $info) {
 					$qty = $info['quantity'];
 					$price = $info['price'];
-					$total = $price * $qty * 1;
+					$total = $price * $qty * $days;
 					// Format room name: insert space before capital letters except first
-					$formattedRoomName = preg_replace('/(?<!^)([A-Z])/', ' $1', $roomName);
+					$formattedRoomName = isset($info['name']) ? $info['name'] : preg_replace('/(?<!^)([A-Z])/', ' $1', $roomName);
 					// Build the output
 					$room_output .= " <div class='ttbm_hotel_room'>";
 					$room_output .= " <div class='ttbm_hotel_room_name'> Room Name: {$formattedRoomName}</div> ";
 					$room_output .= " <div class='ttbm_hotel_qty'>Qty: {$qty}</div> ";
-					$room_output .= " <div class='ttbm_hotel_price'>Price: ( " . number_format($price, 2) . " {$currency_symbol} x {$qty} x 1 ) = " . number_format($total, 2) . " {$currency_symbol}</div> ";
+					$room_output .= " <div class='ttbm_hotel_price'>Price: ( " . number_format($price, 2) . " {$currency_symbol} x {$qty} x {$days} ) = " . number_format($total, 2) . " {$currency_symbol}</div> ";
 					$room_output .= " </div> ";
 				}
 				$room_output .= '</div>';
-				$date = explode(" - ", $date_range);
-				$check_in = gmdate('Y-m-d', strtotime($date[0]));
-				$check_out = gmdate('Y-m-d', strtotime($date[1]));
-				$check_in_date = gmdate('Y-m-d', strtotime($date[0]));
-				$check_out_date = gmdate('Y-m-d', strtotime($date[1]));
-				$datetime1 = new DateTime($check_in_date);
-				$datetime2 = new DateTime($check_out_date);
-				$interval = $datetime1->diff($datetime2);
-				$days = $interval->days;
-				$post_id = get_post_meta($hotel_id, 'link_wc_product', true);
-				$price = isset($_REQUEST['price']) ? sanitize_text_field(wp_unslash($_REQUEST['price'])) : 0;
+				$post_id = absint(get_post_meta($hotel_id, 'link_wc_product', true));
+				if (!$post_id || !wc_get_product($post_id)) {
+					wp_send_json_error(['message' => __('The selected hotel is not linked to a purchasable product.', 'tour-booking-manager')]);
+				}
 				$quantity = intval(wp_unslash(20));
 				$hotel_info = array();
 				$hotel_info['hotel_id'] = $hotel_id;
@@ -196,6 +272,7 @@
 					'description_order' => $room_output,
 					'room_ordered_data_info' => $room_data_info,
 					'price' => $price,
+					'custom_price' => $price,
 					'ttbm_tp' => $price,
 					'line_total' => $price,
 					'line_subtotal' => $price,
@@ -265,7 +342,15 @@
 			public function set_custom_price_cart_item( $cart_item_data, $product_id) {
 
 				if (isset($cart_item_data['ttbm_hotel_booking']) && (isset($_POST['nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'ttbm_frontend_nonce'))) {
-                    $cart_item_data['custom_price'] = isset($_POST['price']) ? floatval(sanitize_text_field(wp_unslash($_POST['price']))) :0;
+					if (empty($cart_item_data['custom_price'])) {
+						$hotel_id = isset($_POST['hotel_id']) ? absint(wp_unslash($_POST['hotel_id'])) : 0;
+						$date_range = isset($_POST['date_range']) ? sanitize_text_field(wp_unslash($_POST['date_range'])) : '';
+						$room_data_info = isset($_POST['room_data_info']) ? json_decode(wp_unslash($_POST['room_data_info']), true) : [];
+						$booking_request = $this->build_hotel_booking_request($hotel_id, $date_range, $room_data_info);
+						if (!is_wp_error($booking_request)) {
+							$cart_item_data['custom_price'] = $booking_request['total_price'];
+						}
+					}
 
 				}
 				return $cart_item_data;

--- a/lib/classes/class-taxonomy-edit.php
+++ b/lib/classes/class-taxonomy-edit.php
@@ -47,7 +47,7 @@
 					return;
 				$option['field_name'] = $id;
 				$option_value = get_term_meta($term_id, $id, true);
-				$option['value'] = is_serialized($option_value) ? unserialize($option_value) : $option_value;
+				$option['value'] = is_serialized($option_value) ? @unserialize($option_value, ['allowed_classes' => false]) : $option_value;
 				if (sizeof($option) > 0 && isset($option['type'])) {
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					echo mep_field_generator($option['type'], $option);

--- a/templates/ticket/hotel_book_ticket.php
+++ b/templates/ticket/hotel_book_ticket.php
@@ -2,7 +2,15 @@
 if ( ! defined( 'ABSPATH' ) ) {
     die;
 }
-if ( isset($_POST['nonce']) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'ttbm_hotel_nonce') || 1 ){
+$has_valid_nonce = (
+    isset($_POST['nonce']) &&
+    wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'ttbm_frontend_nonce')
+) || (
+    isset($_POST['ttbm_hotel_nonce']) &&
+    wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ttbm_hotel_nonce'])), 'ttbm_hotel_nonce')
+);
+
+if ( $has_valid_nonce ) {
 	$hotel_id = $hotel_id ?? '';
     $ttbm_post_id = $ttbm_post_id ?? get_the_id();
     //$room_lists = TTBM_Global_Function::get_post_info( $hotel_id, 'ttbm_room_details', array() );


### PR DESCRIPTION
…data exposure

This changeset addresses multiple verified security weaknesses in the Tour Booking Manager plugin.

Broken access control:
- Protect enquiry view, delete, and reply AJAX handlers with explicit capability and object-level authorization checks.
- Add capability checks to admin AJAX endpoints that previously relied only on the shared ttbm_admin_nonce.
- Require edit_post or manage_options where object mutation or access is admin-only.

Sensitive data exposure:
- Make internal enquiry and hotel booking post types non-public and not publicly queryable.
- Exclude internal booking/enquiry records from search and disable rewrite/archive exposure.

Booking integrity:
- Remove the unconditional nonce bypass from the hotel booking ticket template.
- Stop trusting client-supplied hotel booking totals and room prices.
- Recompute room availability and booking totals server-side before adding items to cart.
- Reject invalid, unavailable, or tampered room booking requests.

Save handler hardening:
- Fix fail-open save_post nonce/autosave/capability guards in tour and hotel settings handlers.
- Ensure invalid nonce, autosave, and missing edit capability each abort writes independently.

Serialization hardening:
- Replace raw unserialize() usage in plugin-owned code paths with allowed_classes => false where applicable.

Verification:
- Ran php -l on all modified PHP files.
- Re-scanned for the original nonce bypass and fail-open save_post patterns after patching.