### PR TITLE
Fix hidden TTBM placeholder price leaking into cart

### DIFF
--- a/admin/TTBM_Hidden_Hotel_Product.php
+++ b/admin/TTBM_Hidden_Hotel_Product.php
@@ -15,6 +15,14 @@ if (!class_exists('TTBM_Hidden_Hotel_Product')) {
             add_action('init', [$this, 'get_all_hidden_product_id']);
             add_filter('wpseo_exclude_from_sitemap_by_post_ids', [$this, 'get_all_hidden_product_id']);
         }
+        private function sync_hidden_product_price($product_id) {
+            update_post_meta($product_id, '_price', 0);
+            update_post_meta($product_id, '_regular_price', 0);
+            update_post_meta($product_id, '_sale_price', '');
+            if (function_exists('wc_delete_product_transients')) {
+                wc_delete_product_transients($product_id);
+            }
+        }
         public function create_hidden_wc_product($post_id, $title) {
             $new_post = array(
                 'post_title' => $title,
@@ -28,7 +36,7 @@ if (!class_exists('TTBM_Hidden_Hotel_Product')) {
             $pid = wp_insert_post($new_post);
             update_post_meta($post_id, 'link_wc_product', $pid);
             update_post_meta($pid, 'link_ttbm_id', $post_id);
-            update_post_meta($pid, '_price', 0.01);
+            $this->sync_hidden_product_price($pid);
             update_post_meta($pid, '_sold_individually', 'yes');
             update_post_meta($pid, '_virtual', 'yes');
             $terms = array('exclude-from-catalog', 'exclude-from-search');
@@ -50,7 +58,7 @@ if (!class_exists('TTBM_Hidden_Hotel_Product')) {
                 $product_type = 'yes';
                 update_post_meta($post_id, 'link_wc_product', $pid);
                 update_post_meta($pid, 'link_ttbm_id', $post_id);
-                update_post_meta($pid, '_price', 0.01);
+                $this->sync_hidden_product_price($pid);
                 update_post_meta($pid, '_sold_individually', 'yes');
                 update_post_meta($pid, '_virtual', $product_type);
                 $terms = array('exclude-from-catalog', 'exclude-from-search');
@@ -100,6 +108,7 @@ if (!class_exists('TTBM_Hidden_Hotel_Product')) {
                 update_post_meta($product_id, '_manage_stock', 'no');
                 update_post_meta($product_id, '_virtual', $product_type);
                 update_post_meta($product_id, '_sold_individually', 'yes');
+                $this->sync_hidden_product_price($product_id);
                 $my_post = array(
                     'ID' => $product_id,
                     'post_title' => $event_name,

--- a/admin/TTBM_Hidden_Product.php
+++ b/admin/TTBM_Hidden_Product.php
@@ -14,6 +14,14 @@
 				add_action('init', [$this, 'get_all_hidden_product_id']);
 				add_filter('wpseo_exclude_from_sitemap_by_post_ids', [$this, 'get_all_hidden_product_id']);
 			}
+			private function sync_hidden_product_price($product_id) {
+				update_post_meta($product_id, '_price', 0);
+				update_post_meta($product_id, '_regular_price', 0);
+				update_post_meta($product_id, '_sale_price', '');
+				if (function_exists('wc_delete_product_transients')) {
+					wc_delete_product_transients($product_id);
+				}
+			}
 			public function create_hidden_wc_product($post_id, $title) {
 				$new_post = array(
 					'post_title' => $title,
@@ -27,7 +35,7 @@
 				$pid = wp_insert_post($new_post);
 				update_post_meta($post_id, 'link_wc_product', $pid);
 				update_post_meta($pid, 'link_ttbm_id', $post_id);
-				update_post_meta($pid, '_price', 0.01);
+				$this->sync_hidden_product_price($pid);
 				update_post_meta($pid, '_sold_individually', 'yes');
 				update_post_meta($pid, '_virtual', 'yes');
 				$terms = array('exclude-from-catalog', 'exclude-from-search');
@@ -49,7 +57,7 @@
 					$product_type = 'yes';
 					update_post_meta($post_id, 'link_wc_product', $pid);
 					update_post_meta($pid, 'link_ttbm_id', $post_id);
-					update_post_meta($pid, '_price', 0.01);
+					$this->sync_hidden_product_price($pid);
 					update_post_meta($pid, '_sold_individually', 'yes');
 					update_post_meta($pid, '_virtual', $product_type);
 					$terms = array('exclude-from-catalog', 'exclude-from-search');
@@ -99,6 +107,7 @@
 					update_post_meta($product_id, '_manage_stock', 'no');
 					update_post_meta($product_id, '_virtual', $product_type);
 					update_post_meta($product_id, '_sold_individually', 'yes');
+					$this->sync_hidden_product_price($product_id);
 					$my_post = array(
 						'ID' => $product_id,
 						'post_title' => $event_name,

--- a/inc/TTBM_Woocommerce.php
+++ b/inc/TTBM_Woocommerce.php
@@ -12,6 +12,8 @@
 				add_filter('woocommerce_add_cart_item_data', array($this, 'add_cart_item_data'), 90, 3);
 				add_action('woocommerce_before_calculate_totals', array($this, 'before_calculate_totals'), 90, 1);
 				add_filter('woocommerce_cart_item_thumbnail', array($this, 'cart_item_thumbnail'), 90, 3);
+				add_filter('woocommerce_cart_item_price', array($this, 'cart_item_price'), 90, 3);
+				add_filter('woocommerce_cart_item_subtotal', array($this, 'cart_item_subtotal'), 90, 3);
 				add_filter('woocommerce_get_item_data', array($this, 'get_item_data'), 90, 2);
 				//************//
 				add_action('woocommerce_after_checkout_validation', array($this, 'after_checkout_validation'));
@@ -46,19 +48,74 @@
 				// echo '<pre>';print_r($cart_item_data);echo '</pre>';die();
 				return $cart_item_data;
 			}
-			public function before_calculate_totals($cart_object) {
-				foreach ($cart_object->cart_contents as $value) {
-					$ttbm_id = array_key_exists('ttbm_id', $value) ? $value['ttbm_id'] : 0;
-					$ttbm_id = TTBM_Function::post_id_multi_language($ttbm_id);
-					if (get_post_type($ttbm_id) == TTBM_Function::get_cpt_name()) {
-						$total_price = array_key_exists('ttbm_tp', $value) ? $value['ttbm_tp'] : 0;
-						$value['data']->set_price($total_price);
-						$value['data']->set_regular_price($total_price);
-						$value['data']->set_sale_price($total_price);
-						$value['data']->set_sold_individually('yes');
-						$value['data']->get_price();
+			private function get_ttbm_cart_total($cart_item) {
+				$ttbm_id = array_key_exists('ttbm_id', $cart_item) ? $cart_item['ttbm_id'] : 0;
+				$ttbm_id = TTBM_Function::post_id_multi_language($ttbm_id);
+				if (get_post_type($ttbm_id) != TTBM_Function::get_cpt_name()) {
+					return null;
+				}
+				foreach (array('ttbm_tp', 'custom_price') as $price_key) {
+					if (array_key_exists($price_key, $cart_item) && $cart_item[$price_key] !== '') {
+						return (float) wc_format_decimal($cart_item[$price_key]);
 					}
 				}
+				$total_price = 0.0;
+				$has_price_data = false;
+				$hotel_info = isset($cart_item['ttbm_hotel_info']) && is_array($cart_item['ttbm_hotel_info']) ? $cart_item['ttbm_hotel_info'] : array();
+				$hotel_days = !empty($hotel_info['ttbm_hotel_num_of_day']) ? max(1, absint($hotel_info['ttbm_hotel_num_of_day'])) : 1;
+				$ticket_type = isset($cart_item['ttbm_ticket_info']) && is_array($cart_item['ttbm_ticket_info']) ? $cart_item['ttbm_ticket_info'] : array();
+				foreach ($ticket_type as $ticket) {
+					$ticket_price = isset($ticket['ticket_price']) ? (float) wc_format_decimal($ticket['ticket_price']) : 0.0;
+					$ticket_qty = isset($ticket['ticket_qty']) ? absint($ticket['ticket_qty']) : 0;
+					if ($ticket_qty < 1) {
+						continue;
+					}
+					$has_price_data = true;
+					$total_price += $ticket_price * $ticket_qty * $hotel_days;
+				}
+				$extra_service = isset($cart_item['ttbm_extra_service_info']) && is_array($cart_item['ttbm_extra_service_info']) ? $cart_item['ttbm_extra_service_info'] : array();
+				foreach ($extra_service as $service) {
+					$service_price = isset($service['service_price']) ? (float) wc_format_decimal($service['service_price']) : 0.0;
+					$service_qty = isset($service['service_qty']) ? absint($service['service_qty']) : 0;
+					if ($service_qty < 1) {
+						continue;
+					}
+					$has_price_data = true;
+					$total_price += $service_price * $service_qty;
+				}
+				return $has_price_data ? $total_price : null;
+			}
+			private function format_ttbm_cart_total($cart_item, $total_price) {
+				if (function_exists('WC') && WC()->cart && isset($cart_item['data'])) {
+					if (WC()->cart->display_prices_including_tax()) {
+						$total_price = wc_get_price_including_tax($cart_item['data'], array('qty' => 1, 'price' => $total_price));
+					} else {
+						$total_price = wc_get_price_excluding_tax($cart_item['data'], array('qty' => 1, 'price' => $total_price));
+					}
+				}
+				return wc_price($total_price);
+			}
+			public function before_calculate_totals($cart_object) {
+				foreach ($cart_object->cart_contents as $cart_item_key => $value) {
+					$total_price = $this->get_ttbm_cart_total($value);
+					if ($total_price === null) {
+						continue;
+					}
+					$cart_object->cart_contents[$cart_item_key]['ttbm_tp'] = $total_price;
+					$cart_object->cart_contents[$cart_item_key]['data']->set_price($total_price);
+					$cart_object->cart_contents[$cart_item_key]['data']->set_regular_price($total_price);
+					$cart_object->cart_contents[$cart_item_key]['data']->set_sale_price($total_price);
+					$cart_object->cart_contents[$cart_item_key]['data']->set_sold_individually('yes');
+					$cart_object->cart_contents[$cart_item_key]['data']->get_price();
+				}
+			}
+			public function cart_item_price($price, $cart_item) {
+				$total_price = $this->get_ttbm_cart_total($cart_item);
+				return $total_price === null ? $price : $this->format_ttbm_cart_total($cart_item, $total_price);
+			}
+			public function cart_item_subtotal($subtotal, $cart_item) {
+				$total_price = $this->get_ttbm_cart_total($cart_item);
+				return $total_price === null ? $subtotal : $this->format_ttbm_cart_total($cart_item, $total_price);
 			}
 			public function cart_item_thumbnail($thumbnail, $cart_item) {
 				$ttbm_id = array_key_exists('ttbm_id', $cart_item) ? $cart_item['ttbm_id'] : 0;


### PR DESCRIPTION
TTBM creates hidden WooCommerce virtual products for tours and hotels with a hardcoded _price value of 0.01. When WooCommerce renders the cart line item price/subtotal, that placeholder could leak into the visible cart columns even though the booking details and actual ticket totals were calculated separately by TTBM. This produced confusing 0.01 EUR prices on the basket page for clients.

This change fixes the issue in two places. First, the cart pricing pipeline now derives the line amount from saved TTBM booking data (ttbm_tp/custom_price, with a fallback recomputation from ticket and extra-service data) and applies that value consistently during total calculation and cart display filters. Second, hidden linked WooCommerce products are now synced with a neutral zero price instead of 0.01, including when the linked hidden product is created or resaved, so the placeholder price cannot leak back into the storefront.

The patch updates TTBM_Woocommerce cart pricing hooks and the hidden product builders for both tours and hotels. PHP syntax was validated for all modified files.