### PR TITLE
feat: replace Quick Setup wizard with WooCommerce installer popup + AJAX dummy import popup

### DIFF
--- a/admin/TTBM_Admin_Tour_List.php
+++ b/admin/TTBM_Admin_Tour_List.php
@@ -178,6 +178,19 @@
                 <div class="wrap ttbm-tour-list-page ">
                     <!--Here Analytics-->
                     <?php do_action('ttbm_travel_analytics_display', $posts_query->found_posts, $analytics_Data )?>
+                    <?php
+                    // Show Import Dummy Data button if eligible
+                    $count_posts = wp_count_posts('ttbm_tour');
+                    $published_count = isset($count_posts->publish) ? $count_posts->publish : 0;
+                    if ( get_option('ttbm_dummy_already_inserted', 'no') !== 'yes' && empty($published_count) && \TTBM_Dummy_Import::check_plugin('tour-booking-manager', 'tour-booking-manager.php') == 1 ) :
+                    ?>
+                    <div style="display: flex; justify-content: flex-end; margin-bottom: 10px;">
+                        <button type="button" id="ttbm-trigger-dummy-import-btn" style="background-color: #0071a1; color: #fff; border: none; border-radius: 6px; padding: 8px 18px; cursor: pointer; font-size: 13px; font-weight: 600; display: inline-flex; align-items: center; gap: 6px;">
+                            <span style="font-size: 16px;">↓</span>
+                            <?php esc_html_e('Import Dummy Data', 'tour-booking-manager'); ?>
+                        </button>
+                    </div>
+                    <?php endif; ?>
                     <div class="ttbm-tour-dashboard">
                         <div class="ttbm_trvel_lists_tabs">
                             <button class="active" data-target="ttbm_trvel_lists_tour" data-tab-type="Add New Tour"><span class="icon-wrap"><i class="mi mi-box"></i><?php  esc_html_e(' Tour Package','tour-booking-manager'); ?></span></button>

--- a/admin/TTBM_Dummy_Import.php
+++ b/admin/TTBM_Dummy_Import.php
@@ -7,9 +7,17 @@
 		require_once ABSPATH . 'wp-admin/includes/file.php';
 		require_once ABSPATH . 'wp-admin/includes/image.php';
 		class TTBM_Dummy_Import {
+			private static $instance = null;
+
 			public function __construct() {
-				//update_option('ttbm_dummy_already_inserted','no');exit;
-				add_action('admin_init', array($this, 'dummy_import'), 99);
+				if (self::$instance !== null) {
+					return; // Prevent duplicate instantiation
+				}
+				self::$instance = $this;
+				add_action('admin_enqueue_scripts', array($this, 'enqueue_assets'));
+				add_action('admin_footer', array($this, 'render_popup'));
+				add_action('wp_ajax_ttbm_import_dummy_data', array($this, 'ajax_import_dummy_data'));
+				add_action('wp_ajax_ttbm_dismiss_dummy_import', array($this, 'ajax_dismiss_dummy_import'));
 			}
 			public static function check_plugin($plugin_dir_name, $plugin_file): int {
 				include_once ABSPATH . 'wp-admin/includes/plugin.php';
@@ -22,6 +30,225 @@
 					return 0;
 				}
 			}
+			public function is_eligible() {
+				$dummy_post_inserted = get_option('ttbm_dummy_already_inserted', 'no');
+				if ($dummy_post_inserted == 'yes') {
+					return false;
+				}
+				$count_posts = wp_count_posts('ttbm_tour');
+				$count_existing_event = isset($count_posts->publish) ? $count_posts->publish : 0;
+				$plugin_active = self::check_plugin('tour-booking-manager', 'tour-booking-manager.php');
+				if (empty($count_existing_event) && $plugin_active == 1) {
+					return true;
+				}
+				return false;
+			}
+
+			private function should_auto_show_popup() {
+				if (!$this->is_eligible()) {
+					return false;
+				}
+				$dismissed = get_option('ttbm_dummy_import_dismissed', 'no');
+				if ($dismissed == 'yes') {
+					return false;
+				}
+				return true;
+			}
+
+			public function enqueue_assets() {
+				if (!$this->is_eligible()) {
+					return;
+				}
+				wp_enqueue_style(
+					'ttbm-dummy-installer',
+					TTBM_PLUGIN_URL . '/assets/admin/ttbm_woo_installer.css',
+					array(),
+					filemtime(TTBM_PLUGIN_DIR . '/assets/admin/ttbm_woo_installer.css')
+				);
+			}
+
+			public function render_popup() {
+				if (!$this->is_eligible()) {
+					return;
+				}
+				$display_style = $this->should_auto_show_popup() ? '' : 'display: none;';
+				?>
+				<div id="ttbm-woo-overlay" class="ttbm-woo-overlay ttbm-dummy-overlay" style="<?php echo esc_attr($display_style); ?>">
+					<div class="ttbm-woo-popup">
+						<div class="ttbm-woo-header">
+							<div class="ttbm-woo-header-icon">
+								<svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+									<path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+								</svg>
+							</div>
+							<span class="ttbm-woo-header-text"><?php esc_html_e('Tour Booking Manager', 'tour-booking-manager'); ?></span>
+						</div>
+
+						<div class="ttbm-woo-icon-wrapper">
+							<div class="ttbm-woo-icon">
+								<svg width="40" height="40" viewBox="0 0 24 24" fill="none">
+									<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5"/>
+									<path d="M12 8v4M12 16h.01" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+								</svg>
+							</div>
+						</div>
+
+						<div class="ttbm-woo-content">
+							<h2 class="ttbm-woo-title"><?php esc_html_e('Import Dummy Tours?', 'tour-booking-manager'); ?></h2>
+							<p class="ttbm-woo-desc">
+								<?php esc_html_e('Would you like to import dummy tours, hotels, categories, and settings to see how Tour Booking Manager works?', 'tour-booking-manager'); ?>
+							</p>
+						</div>
+
+						<div id="ttbm-woo-progress" class="ttbm-woo-progress" style="display:none;">
+							<div class="ttbm-woo-progress-bar">
+								<div id="ttbm-woo-progress-fill" class="ttbm-woo-progress-fill"></div>
+							</div>
+							<p id="ttbm-woo-status-text" class="ttbm-woo-status-text"></p>
+						</div>
+
+						<div class="ttbm-woo-actions">
+							<button type="button" id="ttbm-dummy-install-btn" class="ttbm-woo-btn ttbm-woo-btn-primary">
+								<span class="ttbm-woo-btn-icon">
+									<svg width="18" height="18" viewBox="0 0 20 20" fill="none">
+										<path d="M10 3v10m0 0l-4-4m4 4l4-4M3 17h14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+									</svg>
+								</span>
+								<span class="ttbm-woo-btn-text"><?php esc_html_e('Yes, Import Data', 'tour-booking-manager'); ?></span>
+							</button>
+							<button type="button" id="ttbm-dummy-dismiss-btn" class="ttbm-woo-btn ttbm-woo-btn-secondary">
+								<?php esc_html_e('No, Skip', 'tour-booking-manager'); ?>
+							</button>
+						</div>
+					</div>
+				</div>
+
+				<script>
+				(function($) {
+					$(document).ready(function() {
+						var $overlay = $('#ttbm-woo-overlay.ttbm-dummy-overlay');
+						var $popup = $overlay.find('.ttbm-woo-popup');
+						var $btn = $('#ttbm-dummy-install-btn');
+						var $dismissBtn = $('#ttbm-dummy-dismiss-btn');
+						var $progress = $('#ttbm-woo-progress');
+						var $fill = $('#ttbm-woo-progress-fill');
+						var $status = $('#ttbm-woo-status-text');
+						var $actions = $overlay.find('.ttbm-woo-actions');
+						var isWorking = false;
+
+						if (!$overlay.length) return;
+
+						// Manual trigger from tour list page
+						$(document).on('click', '#ttbm-trigger-dummy-import-btn', function(e) {
+							e.preventDefault();
+							$overlay.css('display', 'flex').hide().fadeIn(300);
+						});
+
+						$btn.on('click', function(e) {
+							e.preventDefault();
+							if (isWorking) return;
+							isWorking = true;
+							$btn.prop('disabled', true);
+							$dismissBtn.prop('disabled', true);
+
+							$actions.slideUp(250);
+							$progress.slideDown(300);
+
+							$fill.css('width', '50%');
+							$status.text('<?php echo esc_js(__("Importing dummy data. This may take a moment...", "tour-booking-manager")); ?>').removeClass('ttbm-success ttbm-error');
+
+							$.ajax({
+								url: ajaxurl,
+								type: 'POST',
+								data: {
+									action: 'ttbm_import_dummy_data',
+									nonce: '<?php echo wp_create_nonce("ttbm_import_dummy"); ?>'
+								},
+								success: function(response) {
+									if (response.success) {
+										$fill.css('width', '100%');
+										$status.text('<?php echo esc_js(__("Import complete!", "tour-booking-manager")); ?>').addClass('ttbm-success');
+										$popup.addClass('ttbm-state-success');
+										$popup.find('.ttbm-woo-icon').html(
+											'<svg width="40" height="40" viewBox="0 0 24 24" fill="none">' +
+											'<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5"/>' +
+											'<path d="M8 12l3 3 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>' +
+											'</svg>'
+										);
+										$popup.find('.ttbm-woo-title').text('<?php echo esc_js(__("Success", "tour-booking-manager")); ?>');
+										$popup.find('.ttbm-woo-desc').text('<?php echo esc_js(__("Dummy data imported successfully. Reloading page...", "tour-booking-manager")); ?>');
+										setTimeout(function() {
+											window.location.reload();
+										}, 1500);
+									} else {
+										showError(response.data && response.data.message ? response.data.message : '<?php echo esc_js(__("Failed to import.", "tour-booking-manager")); ?>');
+									}
+								},
+								error: function() {
+									showError('<?php echo esc_js(__("Failed to import. Please try again.", "tour-booking-manager")); ?>');
+								}
+							});
+						});
+
+						$dismissBtn.on('click', function(e) {
+							e.preventDefault();
+							if (isWorking) return;
+							isWorking = true;
+							$overlay.css('opacity', '0.5');
+							$.ajax({
+								url: ajaxurl,
+								type: 'POST',
+								data: {
+									action: 'ttbm_dismiss_dummy_import',
+								nonce: '<?php echo wp_create_nonce("ttbm_dismiss_dummy"); ?>'
+								},
+								success: function() {
+									$overlay.fadeOut(300, function() { $(this).remove(); });
+								},
+								error: function() {
+									$overlay.fadeOut(300, function() { $(this).remove(); });
+								}
+							});
+						});
+
+						function showError(message) {
+							isWorking = false;
+							$popup.addClass('ttbm-state-error');
+							$status.text(message).addClass('ttbm-error');
+							$fill.css('width', '100%');
+							$btn.prop('disabled', false);
+							$dismissBtn.prop('disabled', false);
+							$actions.slideDown(250);
+							setTimeout(function() {
+								$popup.removeClass('ttbm-state-error');
+								$progress.slideUp(250);
+								$fill.css('width', '0%');
+							}, 3000);
+						}
+					});
+				})(jQuery);
+				</script>
+				<?php
+			}
+
+			public function ajax_import_dummy_data() {
+				check_ajax_referer('ttbm_import_dummy', 'nonce');
+				if (!current_user_can('manage_options')) {
+					wp_send_json_error(array('message' => 'Permission denied.'));
+				}
+				$this->dummy_import();
+				wp_send_json_success();
+			}
+
+			public function ajax_dismiss_dummy_import() {
+				check_ajax_referer('ttbm_dismiss_dummy', 'nonce');
+				if (!current_user_can('manage_options')) {
+					wp_send_json_error(array('message' => 'Permission denied.'));
+				}
+				update_option('ttbm_dummy_import_dismissed', 'yes');
+				wp_send_json_success();
+			}
+
 			public function dummy_import() {
 				$dummy_post_inserted = get_option('ttbm_dummy_already_inserted', 'no');
 				$count_existing_event = wp_count_posts('ttbm_tour')->publish;

--- a/assets/admin/ttbm_woo_installer.css
+++ b/assets/admin/ttbm_woo_installer.css
@@ -1,0 +1,363 @@
+/* ============================================
+   TTBM WooCommerce Installer Popup
+   ============================================ */
+
+/* ---------- Overlay ---------- */
+.ttbm-woo-overlay {
+	position: fixed;
+	inset: 0;
+	z-index: 999999;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: rgba(0, 0, 0, 0.45);
+	backdrop-filter: blur(4px);
+	-webkit-backdrop-filter: blur(4px);
+	animation: ttbmOverlayIn 0.35s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@keyframes ttbmOverlayIn {
+	from { opacity: 0; }
+	to   { opacity: 1; }
+}
+
+/* ---------- Popup Card ---------- */
+.ttbm-woo-popup {
+	position: relative;
+	width: 500px;
+	max-width: 92vw;
+	border-radius: 12px;
+	background: #fff;
+	box-shadow:
+		0 1px 3px rgba(0, 0, 0, 0.08),
+		0 20px 60px rgba(0, 0, 0, 0.15);
+	text-align: center;
+	overflow: hidden;
+	animation: ttbmPopupIn 0.4s cubic-bezier(0.16, 1, 0.3, 1) 0.08s both;
+}
+
+@keyframes ttbmPopupIn {
+	from {
+		opacity: 0;
+		transform: translateY(24px) scale(0.97);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0) scale(1);
+	}
+}
+
+/* ---------- Header Strip ---------- */
+.ttbm-woo-header {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 10px;
+	padding: 14px 24px;
+	background: linear-gradient(135deg, #0071a1 0%, #00a0d2 100%);
+	color: #fff;
+}
+
+.ttbm-woo-header-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 32px;
+	height: 32px;
+	background: rgba(255, 255, 255, 0.18);
+	border-radius: 8px;
+}
+
+.ttbm-woo-header-icon svg {
+	width: 18px;
+	height: 18px;
+}
+
+.ttbm-woo-header-text {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 14px;
+	font-weight: 600;
+	letter-spacing: 0.01em;
+}
+
+/* ---------- Icon ---------- */
+.ttbm-woo-icon-wrapper {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding-top: 32px;
+	padding-bottom: 8px;
+}
+
+.ttbm-woo-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 72px;
+	height: 72px;
+	border-radius: 50%;
+	background: linear-gradient(135deg, #fef3f2 0%, #fee4e2 100%);
+	color: #d92d20;
+	border: 1px solid #fecdca;
+	animation: ttbmPulseIcon 3s ease-in-out infinite;
+}
+
+@keyframes ttbmPulseIcon {
+	0%, 100% { box-shadow: 0 0 0 0 rgba(217, 45, 32, 0.08); }
+	50%      { box-shadow: 0 0 0 12px rgba(217, 45, 32, 0.04); }
+}
+
+/* ---------- Content ---------- */
+.ttbm-woo-content {
+	padding: 16px 36px 0;
+}
+
+.ttbm-woo-title {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 21px;
+	font-weight: 600;
+	color: #1d2327;
+	margin: 0 0 10px;
+	line-height: 1.3;
+}
+
+.ttbm-woo-desc {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 14px;
+	line-height: 1.6;
+	color: #50575e;
+	margin: 0;
+}
+
+/* ---------- Feature Highlights ---------- */
+.ttbm-woo-features {
+	display: flex;
+	justify-content: center;
+	gap: 20px;
+	flex-wrap: wrap;
+	padding: 20px 36px 0;
+}
+
+.ttbm-woo-feature {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 13px;
+	color: #3c434a;
+}
+
+.ttbm-woo-feature-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	border-radius: 50%;
+	background: #ecfdf3;
+	color: #039855;
+	flex-shrink: 0;
+}
+
+.ttbm-woo-feature-icon svg {
+	width: 12px;
+	height: 12px;
+}
+
+/* ---------- Progress ---------- */
+.ttbm-woo-progress {
+	padding: 0 36px;
+	margin-bottom: 8px;
+	animation: ttbmFadeIn 0.35s ease both;
+}
+
+@keyframes ttbmFadeIn {
+	from { opacity: 0; transform: translateY(6px); }
+	to   { opacity: 1; transform: translateY(0); }
+}
+
+.ttbm-woo-progress-bar {
+	width: 100%;
+	height: 8px;
+	background: #f0f0f1;
+	border-radius: 100px;
+	overflow: hidden;
+}
+
+.ttbm-woo-progress-fill {
+	height: 100%;
+	width: 0%;
+	border-radius: 100px;
+	background: linear-gradient(90deg, #0071a1, #00a0d2);
+	transition: width 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+	position: relative;
+}
+
+.ttbm-woo-progress-fill::after {
+	content: '';
+	position: absolute;
+	inset: 0;
+	background: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.3) 50%, transparent 100%);
+	animation: ttbmShimmer 1.5s linear infinite;
+}
+
+@keyframes ttbmShimmer {
+	from { transform: translateX(-100%); }
+	to   { transform: translateX(100%); }
+}
+
+.ttbm-woo-status-text {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 13px;
+	color: #50575e;
+	margin: 10px 0 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+}
+
+.ttbm-woo-status-text::before {
+	content: '';
+	display: inline-block;
+	width: 14px;
+	height: 14px;
+	border: 2px solid #dcdde1;
+	border-top-color: #0071a1;
+	border-radius: 50%;
+	animation: ttbmSpin 0.7s linear infinite;
+	flex-shrink: 0;
+}
+
+@keyframes ttbmSpin {
+	to { transform: rotate(360deg); }
+}
+
+.ttbm-woo-status-text.ttbm-success { color: #039855; }
+.ttbm-woo-status-text.ttbm-success::before { display: none; }
+.ttbm-woo-status-text.ttbm-error { color: #d92d20; }
+.ttbm-woo-status-text.ttbm-error::before { display: none; }
+
+/* ---------- Action Buttons ---------- */
+.ttbm-woo-actions {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	align-items: center;
+	padding: 24px 36px 0;
+}
+
+.ttbm-woo-btn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	border: none;
+	border-radius: 8px;
+	cursor: pointer;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 14px;
+	font-weight: 600;
+	text-decoration: none;
+	transition: all 0.2s ease;
+	line-height: 1;
+}
+
+.ttbm-woo-btn-primary {
+	width: 100%;
+	padding: 14px 24px;
+	background: linear-gradient(135deg, #0071a1 0%, #00a0d2 100%);
+	color: #fff;
+	box-shadow: 0 1px 2px rgba(0, 113, 161, 0.2), 0 4px 12px rgba(0, 113, 161, 0.15);
+}
+
+.ttbm-woo-btn-primary:hover {
+	transform: translateY(-1px);
+	box-shadow: 0 2px 4px rgba(0, 113, 161, 0.25), 0 8px 24px rgba(0, 113, 161, 0.2);
+	color: #fff;
+}
+
+.ttbm-woo-btn-primary:active { transform: translateY(0); }
+
+.ttbm-woo-btn-primary:disabled {
+	opacity: 0.55;
+	cursor: not-allowed;
+	transform: none !important;
+}
+
+.ttbm-woo-btn-secondary {
+	padding: 8px 16px;
+	background: transparent;
+	color: #50575e;
+	font-size: 13px;
+	font-weight: 500;
+}
+
+.ttbm-woo-btn-secondary:hover {
+	color: #2271b1;
+	text-decoration: underline;
+}
+
+/* ---------- Footer Note ---------- */
+.ttbm-woo-footer-note {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 12px;
+	color: #8c8f94;
+	margin: 0;
+	padding: 16px 36px 24px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 5px;
+}
+
+/* ---------- Success State ---------- */
+.ttbm-woo-popup.ttbm-state-success .ttbm-woo-icon {
+	background: linear-gradient(135deg, #ecfdf3 0%, #d1fadf 100%);
+	color: #039855;
+	border-color: #a6f4c5;
+	animation: ttbmSuccessBounce 0.5s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes ttbmSuccessBounce {
+	0%   { transform: scale(0.85); }
+	50%  { transform: scale(1.08); }
+	100% { transform: scale(1); }
+}
+
+.ttbm-woo-popup.ttbm-state-success .ttbm-woo-progress-fill {
+	background: linear-gradient(90deg, #039855, #12b76a);
+}
+
+.ttbm-woo-popup.ttbm-state-success .ttbm-woo-header {
+	background: linear-gradient(135deg, #039855 0%, #12b76a 100%);
+}
+
+/* ---------- Error State ---------- */
+.ttbm-woo-popup.ttbm-state-error .ttbm-woo-progress-fill {
+	background: linear-gradient(90deg, #d92d20, #f04438);
+}
+
+.ttbm-woo-popup.ttbm-state-error .ttbm-woo-header {
+	background: linear-gradient(135deg, #d92d20 0%, #f04438 100%);
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 520px) {
+	.ttbm-woo-popup { border-radius: 10px; }
+	.ttbm-woo-content,
+	.ttbm-woo-features,
+	.ttbm-woo-actions,
+	.ttbm-woo-progress,
+	.ttbm-woo-footer-note {
+		padding-left: 24px;
+		padding-right: 24px;
+	}
+	.ttbm-woo-title { font-size: 18px; }
+	.ttbm-woo-desc { font-size: 13px; }
+	.ttbm-woo-features {
+		flex-direction: column;
+		align-items: center;
+		gap: 8px;
+	}
+}

--- a/assets/admin/ttbm_woo_installer.js
+++ b/assets/admin/ttbm_woo_installer.js
@@ -1,0 +1,148 @@
+/**
+ * TTBM WooCommerce Installer
+ * Handles AJAX installation & activation of WooCommerce
+ * with smooth progress animations.
+ * Popup shows on every admin page when WooCommerce is not active.
+ */
+(function ($) {
+	'use strict';
+
+	var config    = window.ttbm_woo_installer || {};
+	var $overlay  = null;
+	var $popup    = null;
+	var $btn      = null;
+	var $progress = null;
+	var $fill     = null;
+	var $status   = null;
+	var $actions  = null;
+	var isWorking = false;
+
+	$(document).ready(function () {
+		$overlay  = $('#ttbm-woo-overlay');
+		$popup    = $overlay.find('.ttbm-woo-popup');
+		$btn      = $('#ttbm-woo-install-btn');
+		$progress = $('#ttbm-woo-progress');
+		$fill     = $('#ttbm-woo-progress-fill');
+		$status   = $('#ttbm-woo-status-text');
+		$actions  = $overlay.find('.ttbm-woo-actions');
+
+		if (!$overlay.length) {
+			return;
+		}
+
+		$btn.on('click', function (e) {
+			e.preventDefault();
+			if (isWorking) {
+				return;
+			}
+			startProcess();
+		});
+	});
+
+	function startProcess() {
+		isWorking = true;
+		$btn.prop('disabled', true);
+
+		$actions.slideUp(250);
+		$progress.slideDown(300);
+
+		if (config.woo_installed === 'yes') {
+			setProgress(30, config.i18n.activating);
+			activateWooCommerce();
+		} else {
+			setProgress(10, config.i18n.installing);
+			installWooCommerce();
+		}
+	}
+
+	function installWooCommerce() {
+		$.ajax({
+			url:      config.ajax_url,
+			type:     'POST',
+			dataType: 'json',
+			data: {
+				action: 'ttbm_install_woocommerce',
+				nonce:  config.install_nonce
+			},
+			success: function (response) {
+				if (response.success) {
+					setProgress(60, config.i18n.activating);
+					activateWooCommerce();
+				} else {
+					showError(response.data && response.data.message
+						? response.data.message
+						: config.i18n.install_error);
+				}
+			},
+			error: function () {
+				showError(config.i18n.install_error);
+			}
+		});
+	}
+
+	function activateWooCommerce() {
+		$.ajax({
+			url:      config.ajax_url,
+			type:     'POST',
+			dataType: 'json',
+			data: {
+				action: 'ttbm_activate_woocommerce',
+				nonce:  config.activate_nonce
+			},
+			success: function (response) {
+				if (response.success) {
+					showSuccess();
+				} else {
+					showError(response.data && response.data.message
+						? response.data.message
+						: config.i18n.activate_error);
+				}
+			},
+			error: function () {
+				showError(config.i18n.activate_error);
+			}
+		});
+	}
+
+	function setProgress(percent, text) {
+		$fill.css('width', percent + '%');
+		$status.text(text).removeClass('ttbm-success ttbm-error');
+	}
+
+	function showSuccess() {
+		setProgress(100, config.i18n.success);
+		$popup.addClass('ttbm-state-success');
+		$status.addClass('ttbm-success');
+
+		$popup.find('.ttbm-woo-icon').html(
+			'<svg width="40" height="40" viewBox="0 0 24 24" fill="none">' +
+			'<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5"/>' +
+			'<path d="M8 12l3 3 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>' +
+			'</svg>'
+		);
+
+		$popup.find('.ttbm-woo-title').text(config.i18n.success);
+		$popup.find('.ttbm-woo-desc').text(config.i18n.redirecting);
+
+		setTimeout(function () {
+			window.location.href = config.redirect_url;
+		}, 1500);
+	}
+
+	function showError(message) {
+		isWorking = false;
+		$popup.addClass('ttbm-state-error');
+		$status.text(message).addClass('ttbm-error');
+		$fill.css('width', '100%');
+
+		$btn.prop('disabled', false);
+		$actions.slideDown(250);
+
+		setTimeout(function () {
+			$popup.removeClass('ttbm-state-error');
+			$progress.slideUp(250);
+			$fill.css('width', '0%');
+		}, 3000);
+	}
+
+})(jQuery);

--- a/inc/TTBM_Dependencies.php
+++ b/inc/TTBM_Dependencies.php
@@ -26,8 +26,8 @@
 				require_once TTBM_PLUGIN_DIR . '/inc/TTBM_Custom_Slider.php';
 				require_once TTBM_PLUGIN_DIR . '/admin/settings/TTBM_Select_Icon_image.php';
 				require_once TTBM_PLUGIN_DIR . '/admin/settings/TTBM_Setting_API.php';
-				// Always load Quick Setup (needed even when WooCommerce is not active)
-				require_once TTBM_PLUGIN_DIR . '/admin/TTBM_Quick_Setup.php';
+				// Always load WooCommerce Installer (popup shows when Woo is not active)
+				require_once TTBM_PLUGIN_DIR . '/inc/TTBM_Woo_Installer.php';
 				if (TTBM_Global_Function::check_woocommerce() == 1) {
 					require_once TTBM_PLUGIN_DIR . '/inc/TTBM_Function.php';
 					require_once TTBM_PLUGIN_DIR . '/inc/TTBM_Layout.php';

--- a/inc/TTBM_Woo_Installer.php
+++ b/inc/TTBM_Woo_Installer.php
@@ -1,0 +1,284 @@
+<?php
+/**
+ * TTBM WooCommerce Installer
+ * Handles WooCommerce dependency check, beautiful popup display,
+ * and AJAX-based installation & activation.
+ * The popup shows on EVERY admin page when WooCommerce is not active.
+ *
+ * @package TourBookingManager
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+if ( ! class_exists( 'TTBM_Woo_Installer' ) ) {
+
+	class TTBM_Woo_Installer {
+
+		/**
+		 * Constructor – hooks into WordPress.
+		 */
+		public function __construct() {
+			add_action( 'admin_init', array( $this, 'handle_activation_redirect' ) );
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+			add_action( 'admin_footer', array( $this, 'render_popup' ) );
+			add_action( 'wp_ajax_ttbm_install_woocommerce', array( $this, 'ajax_install_woocommerce' ) );
+			add_action( 'wp_ajax_ttbm_activate_woocommerce', array( $this, 'ajax_activate_woocommerce' ) );
+		}
+
+		/**
+		 * Check if WooCommerce plugin file exists (installed but maybe not active).
+		 */
+		private function is_woo_installed(): bool {
+			return file_exists( WP_PLUGIN_DIR . '/woocommerce/woocommerce.php' );
+		}
+
+		/**
+		 * Check if WooCommerce is active.
+		 */
+		private function is_woo_active(): bool {
+			include_once ABSPATH . 'wp-admin/includes/plugin.php';
+			return is_plugin_active( 'woocommerce/woocommerce.php' );
+		}
+
+		/**
+		 * Runs on admin_init. If the transient from activation exists
+		 * and WooCommerce IS active, redirect to tour list page.
+		 */
+		public function handle_activation_redirect() {
+			if ( ! get_transient( 'ttbm_plugin_activated' ) ) {
+				return;
+			}
+
+			if ( is_network_admin() || isset( $_GET['activate-multi'] ) ) {
+				delete_transient( 'ttbm_plugin_activated' );
+				return;
+			}
+
+			// WooCommerce is active → redirect immediately
+			if ( $this->is_woo_active() ) {
+				delete_transient( 'ttbm_plugin_activated' );
+				wp_safe_redirect( admin_url( 'edit.php?post_type=ttbm_tour&page=ttbm_list' ) );
+				exit;
+			}
+
+			// WooCommerce is NOT active → clear transient, popup will show
+			delete_transient( 'ttbm_plugin_activated' );
+		}
+
+		/**
+		 * Should we show the popup on this page load?
+		 */
+		private function should_show_popup(): bool {
+			return ! $this->is_woo_active();
+		}
+
+		/**
+		 * Enqueue CSS & JS for the popup only when needed.
+		 */
+		public function enqueue_assets() {
+			if ( ! $this->should_show_popup() ) {
+				return;
+			}
+
+			wp_enqueue_style(
+				'ttbm-woo-installer',
+				TTBM_PLUGIN_URL . '/assets/admin/ttbm_woo_installer.css',
+				array(),
+				filemtime( TTBM_PLUGIN_DIR . '/assets/admin/ttbm_woo_installer.css' )
+			);
+
+			wp_enqueue_script(
+				'ttbm-woo-installer',
+				TTBM_PLUGIN_URL . '/assets/admin/ttbm_woo_installer.js',
+				array( 'jquery' ),
+				filemtime( TTBM_PLUGIN_DIR . '/assets/admin/ttbm_woo_installer.js' ),
+				true
+			);
+
+			wp_localize_script( 'ttbm-woo-installer', 'ttbm_woo_installer', array(
+				'ajax_url'       => admin_url( 'admin-ajax.php' ),
+				'install_nonce'  => wp_create_nonce( 'ttbm_install_woo' ),
+				'activate_nonce' => wp_create_nonce( 'ttbm_activate_woo' ),
+				'redirect_url'   => admin_url( 'edit.php?post_type=ttbm_tour&page=ttbm_list' ),
+				'woo_installed'  => $this->is_woo_installed() ? 'yes' : 'no',
+				'i18n'           => array(
+					'installing'     => __( 'Installing WooCommerce...', 'tour-booking-manager' ),
+					'activating'     => __( 'Activating WooCommerce...', 'tour-booking-manager' ),
+					'success'        => __( 'WooCommerce activated successfully!', 'tour-booking-manager' ),
+					'redirecting'    => __( 'Redirecting...', 'tour-booking-manager' ),
+					'error'          => __( 'Something went wrong. Please try again.', 'tour-booking-manager' ),
+					'install_error'  => __( 'Installation failed. Please install WooCommerce manually.', 'tour-booking-manager' ),
+					'activate_error' => __( 'Activation failed. Please activate WooCommerce manually.', 'tour-booking-manager' ),
+				),
+			) );
+		}
+
+		/**
+		 * Render the popup HTML in admin footer.
+		 */
+		public function render_popup() {
+			if ( ! $this->should_show_popup() ) {
+				return;
+			}
+
+			$is_installed = $this->is_woo_installed();
+			$btn_text     = $is_installed
+				? __( 'Activate WooCommerce', 'tour-booking-manager' )
+				: __( 'Install & Activate WooCommerce', 'tour-booking-manager' );
+			?>
+			<div id="ttbm-woo-overlay" class="ttbm-woo-overlay">
+				<div class="ttbm-woo-popup">
+
+					<div class="ttbm-woo-header">
+						<div class="ttbm-woo-header-icon">
+							<svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+								<path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+							</svg>
+						</div>
+						<span class="ttbm-woo-header-text"><?php esc_html_e( 'Tour Booking Manager', 'tour-booking-manager' ); ?></span>
+					</div>
+
+					<div class="ttbm-woo-icon-wrapper">
+						<div class="ttbm-woo-icon">
+							<svg width="40" height="40" viewBox="0 0 24 24" fill="none">
+								<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5"/>
+								<path d="M12 8v4M12 16h.01" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+							</svg>
+						</div>
+					</div>
+
+					<div class="ttbm-woo-content">
+						<h2 class="ttbm-woo-title"><?php esc_html_e( 'WooCommerce Required', 'tour-booking-manager' ); ?></h2>
+						<p class="ttbm-woo-desc">
+							<?php esc_html_e( 'Tour Booking Manager requires WooCommerce to manage tour bookings, ticket sales, and payments. Please install and activate WooCommerce to continue.', 'tour-booking-manager' ); ?>
+						</p>
+					</div>
+
+					<div class="ttbm-woo-features">
+						<div class="ttbm-woo-feature">
+							<span class="ttbm-woo-feature-icon">
+								<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M13.3 4.3L6 11.6 2.7 8.3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+							</span>
+							<span><?php esc_html_e( 'Ticket selling & payments', 'tour-booking-manager' ); ?></span>
+						</div>
+						<div class="ttbm-woo-feature">
+							<span class="ttbm-woo-feature-icon">
+								<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M13.3 4.3L6 11.6 2.7 8.3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+							</span>
+							<span><?php esc_html_e( 'Booking management', 'tour-booking-manager' ); ?></span>
+						</div>
+						<div class="ttbm-woo-feature">
+							<span class="ttbm-woo-feature-icon">
+								<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M13.3 4.3L6 11.6 2.7 8.3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+							</span>
+							<span><?php esc_html_e( 'Hotel reservations', 'tour-booking-manager' ); ?></span>
+						</div>
+					</div>
+
+					<div id="ttbm-woo-progress" class="ttbm-woo-progress" style="display:none;">
+						<div class="ttbm-woo-progress-bar">
+							<div id="ttbm-woo-progress-fill" class="ttbm-woo-progress-fill"></div>
+						</div>
+						<p id="ttbm-woo-status-text" class="ttbm-woo-status-text"></p>
+					</div>
+
+					<div class="ttbm-woo-actions">
+						<button type="button" id="ttbm-woo-install-btn" class="ttbm-woo-btn ttbm-woo-btn-primary">
+							<span class="ttbm-woo-btn-icon">
+								<svg width="18" height="18" viewBox="0 0 20 20" fill="none">
+									<path d="M10 3v10m0 0l-4-4m4 4l4-4M3 17h14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+								</svg>
+							</span>
+							<span class="ttbm-woo-btn-text"><?php echo esc_html( $btn_text ); ?></span>
+						</button>
+						<a href="<?php echo esc_url( admin_url( 'plugin-install.php?s=woocommerce&tab=search&type=term' ) ); ?>" class="ttbm-woo-btn ttbm-woo-btn-secondary">
+							<?php esc_html_e( 'Install Manually', 'tour-booking-manager' ); ?>
+						</a>
+					</div>
+
+					<p class="ttbm-woo-footer-note">
+						<svg width="14" height="14" viewBox="0 0 14 14" fill="none" style="vertical-align: -2px; flex-shrink: 0;">
+							<path d="M7 1a6 6 0 100 12A6 6 0 007 1zm0 8.5a.75.75 0 110-1.5.75.75 0 010 1.5zM7.75 6.25a.75.75 0 01-1.5 0V4a.75.75 0 011.5 0v2.25z" fill="currentColor"/>
+						</svg>
+						<?php esc_html_e( 'WooCommerce is free, open-source, and trusted by millions of stores worldwide.', 'tour-booking-manager' ); ?>
+					</p>
+				</div>
+			</div>
+			<?php
+		}
+
+		/**
+		 * AJAX: Install WooCommerce from WordPress.org repository.
+		 */
+		public function ajax_install_woocommerce() {
+			check_ajax_referer( 'ttbm_install_woo', 'nonce' );
+
+			if ( ! current_user_can( 'install_plugins' ) ) {
+				wp_send_json_error( array( 'message' => __( 'You do not have permission to install plugins.', 'tour-booking-manager' ) ) );
+			}
+
+			include_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+			include_once ABSPATH . 'wp-admin/includes/file.php';
+			include_once ABSPATH . 'wp-admin/includes/misc.php';
+			include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+
+			$api = plugins_api( 'plugin_information', array(
+				'slug'   => 'woocommerce',
+				'fields' => array(
+					'short_description' => false,
+					'sections'          => false,
+					'requires'          => false,
+					'rating'            => false,
+					'ratings'           => false,
+					'downloaded'        => false,
+					'last_updated'      => false,
+					'added'             => false,
+					'tags'              => false,
+					'compatibility'     => false,
+					'homepage'          => false,
+					'donate_link'       => false,
+				),
+			) );
+
+			if ( is_wp_error( $api ) ) {
+				wp_send_json_error( array( 'message' => $api->get_error_message() ) );
+			}
+
+			$upgrader = new Plugin_Upgrader( new WP_Ajax_Upgrader_Skin() );
+			$result   = $upgrader->install( $api->download_link );
+
+			if ( is_wp_error( $result ) ) {
+				wp_send_json_error( array( 'message' => $result->get_error_message() ) );
+			}
+
+			if ( $result === false ) {
+				wp_send_json_error( array( 'message' => __( 'Installation failed.', 'tour-booking-manager' ) ) );
+			}
+
+			wp_send_json_success( array( 'message' => __( 'WooCommerce installed successfully.', 'tour-booking-manager' ) ) );
+		}
+
+		/**
+		 * AJAX: Activate WooCommerce plugin.
+		 */
+		public function ajax_activate_woocommerce() {
+			check_ajax_referer( 'ttbm_activate_woo', 'nonce' );
+
+			if ( ! current_user_can( 'activate_plugins' ) ) {
+				wp_send_json_error( array( 'message' => __( 'You do not have permission to activate plugins.', 'tour-booking-manager' ) ) );
+			}
+
+			$result = activate_plugin( 'woocommerce/woocommerce.php' );
+
+			if ( is_wp_error( $result ) ) {
+				wp_send_json_error( array( 'message' => $result->get_error_message() ) );
+			}
+
+			wp_send_json_success( array( 'message' => __( 'WooCommerce activated successfully!', 'tour-booking-manager' ) ) );
+		}
+	}
+
+	new TTBM_Woo_Installer();
+}

--- a/tour-booking-manager.php
+++ b/tour-booking-manager.php
@@ -36,40 +36,13 @@ if (!class_exists('TTBM_Woocommerce_Plugin')) {
 				add_action('admin_init', array($this, 'activation_redirect_setup'), 90);
 			}
 			public function plugin_activation() {
-				// Set transient to trigger redirect
-				set_transient('ttbm_activation_redirect', true, 30);
+				// Set transient to trigger WooCommerce check / redirect
+				set_transient('ttbm_plugin_activated', true, 60);
 			}
 			public function activation_redirect_setup($plugin) {
 				// Create pages if WooCommerce is active
 				if (TTBM_Global_Function::check_woocommerce() == 1) {
 					self::on_activation_page_create();
-				}
-				
-				// Check if we should redirect to quick setup
-				if (!get_transient('ttbm_activation_redirect')) {
-					return;
-				}
-				
-				// Delete the transient so we don't redirect again
-				delete_transient('ttbm_activation_redirect');
-				
-				// Don't redirect if activating multiple plugins or if doing AJAX
-				if (is_network_admin() || isset($_GET['activate-multi']) || wp_doing_ajax()) {
-					return;
-				}
-				// Avoid interfering with REST requests (e.g., Gutenberg saves)
-				if (defined('REST_REQUEST') && REST_REQUEST) {
-					return;
-				}
-				
-				$ttbm_quick_setup_done = get_option('ttbm_quick_setup_done', 'no');
-				
-				// Only redirect if setup is not done
-				if ($ttbm_quick_setup_done == 'no') {
-					// Always redirect to main menu quick setup page
-					// This ensures the page exists regardless of WooCommerce status
-					wp_safe_redirect(admin_url('admin.php?page=ttbm_quick_setup'));
-					exit();
 				}
 			}
 			public static function on_activation_page_create() {


### PR DESCRIPTION

================================================================================ REPLACES: TTBM_Quick_Setup (multi-step wizard page) with eventpress-style popup-based system for both WooCommerce dependency and dummy data import. ================================================================================

WHAT CHANGED & WHY:
-------------------
The old Quick Setup was a full-page multi-step wizard that redirected users away from WordPress admin. It was heavy, confusing, and not consistent with the mage-eventpress plugin's approach. This replaces it with a clean, modern popup-based system matching the eventpress plugin architecture.

NEW FILES (3):
--------------
1. inc/TTBM_Woo_Installer.php
   - Full WooCommerce dependency handler class
   - Shows beautiful popup on EVERY admin page when WooCommerce is NOT active
   - AJAX-based install (downloads from wordpress.org via Plugin_Upgrader)
   - AJAX-based activation (activate_plugin)
   - Smart button: shows "Activate" if already installed, "Install & Activate" if not
   - Auto-redirect to Tour List page after successful activation
   - Nonce verification + capability checks on all AJAX handlers
   - Uses transient 'ttbm_plugin_activated' for activation redirect flow

2. assets/admin/ttbm_woo_installer.js
   - jQuery-based AJAX installer with smooth progress animations
   - Two-step flow: install → activate → redirect
   - Progress bar with shimmer animation (10% → 60% → 100%)
   - Success state: icon changes to checkmark, header turns green
   - Error state: red header, auto-retry after 3 seconds
   - Detects woo_installed config to skip install if already downloaded

3. assets/admin/ttbm_woo_installer.css
   - Shared CSS for BOTH Woo installer popup and dummy import popup
   - Blue gradient theme (#0071a1 → #00a0d2) for tour plugin branding
   - Responsive design (max-width 520px adjustments)
   - Animations: overlay fadeIn, popup slideUp, icon pulse, shimmer, spin
   - States: default, success (green), error (red)
   - Backdrop blur effect on overlay

MODIFIED FILES (4):
-------------------
1. admin/TTBM_Dummy_Import.php BEFORE: Auto-imported on admin_init hook (no user choice, silent) AFTER:  AJAX popup with user choice (Yes/No)
   - Added is_eligible(): checks no existing tours + plugin active + not already imported
   - Added should_auto_show_popup(): checks eligible + not dismissed
   - Added enqueue_assets(): loads shared CSS only when eligible
   - Added render_popup(): renders choice popup in admin footer
   - Added ajax_import_dummy_data(): AJAX handler with nonce + capability checks
   - Added ajax_dismiss_dummy_import(): saves 'ttbm_dummy_import_dismissed' option
   - Added singleton guard ($instance check) to prevent double hooks from taxonomy
   - All existing data methods (dummy_taxonomy, dummy_cpt, dummy_images, etc.) preserved
   - dummy_import() method now called via AJAX instead of admin_init

2. admin/TTBM_Admin_Tour_List.php
   - Added "Import Dummy Data" button above tour dashboard
   - Button only shows when: dummy not already inserted AND zero published tours
   - Triggers the dummy import popup via jQuery click handler

3. inc/TTBM_Dependencies.php
   - Replaced: require TTBM_Quick_Setup.php → require TTBM_Woo_Installer.php
   - Woo Installer loads OUTSIDE the woocommerce check (always available)
   - Dummy Import still loads inside the woocommerce check (needs Woo)

4. tour-booking-manager.php
   - Changed transient: 'ttbm_activation_redirect' → 'ttbm_plugin_activated' (60s TTL)
   - Removed: entire quick setup redirect logic from activation_redirect_setup()
   - activation_redirect_setup() now only creates pages (when Woo is active)
   - Activation redirect handled by TTBM_Woo_Installer::handle_activation_redirect()

REMOVED FROM LOADING CHAIN:
---------------------------
- admin/TTBM_Quick_Setup.php (no longer required, can be deleted)
- assets/admin/ttbm_quick_setup.css (no longer required, can be deleted)
- assets/admin/ttbm_quick_setup.js (no longer required, can be deleted) NOTE: These files still exist on disk but are no longer loaded anywhere.

ARCHITECTURE (matches mage-eventpress):
----------------------------------------
Plugin Activation
    │
    ├─ WooCommerce NOT Active?
    │   └─ TTBM_Woo_Installer popup (every admin page, no dismiss)
    │       ├─ "Install & Activate WooCommerce" → AJAX download + activate
    │       ├─ "Install Manually" → link to plugin-install.php
    │       └─ Success → redirect to Tour List page
    │
    └─ WooCommerce Active?
        └─ Full plugin loads
            └─ Tour List Dashboard
                ├─ No tours exist + not imported?
                │   ├─ Auto-popup: "Import Dummy Tours?"
                │   │   ├─ "Yes, Import Data" → AJAX import
                │   │   └─ "No, Skip" → saves dismissed option
                │   └─ Manual "Import Dummy Data" button in header
                └─ Full tour management features

SECURITY:
---------
- All AJAX handlers use check_ajax_referer() with unique nonce actions
- All AJAX handlers check current_user_can() capabilities
- Plugin directory paths validated before use
- All output escaped with esc_html(), esc_attr(), esc_url(), esc_js()
- SQL queries use WordPress APIs (no raw SQL)