### PR TITLE
fix: show demo import popup automatically after WooCommerce activation

### DIFF
--- a/admin/TTBM_Dummy_Import.php
+++ b/admin/TTBM_Dummy_Import.php
@@ -31,6 +31,10 @@
 				}
 			}
 			public function is_eligible() {
+				// Only show after WooCommerce is active — prevents popup appearing over the woo-installer screen
+				if ( TTBM_Global_Function::check_woocommerce() != 1 ) {
+					return false;
+				}
 				$dummy_post_inserted = get_option('ttbm_dummy_already_inserted', 'no');
 				if ($dummy_post_inserted == 'yes') {
 					return false;
@@ -47,6 +51,11 @@
 			private function should_auto_show_popup() {
 				if (!$this->is_eligible()) {
 					return false;
+				}
+				// Force-show after WooCommerce was just activated via the installer popup
+				if ( get_transient( 'ttbm_woo_just_activated' ) ) {
+					delete_transient( 'ttbm_woo_just_activated' );
+					return true;
 				}
 				$dismissed = get_option('ttbm_dummy_import_dismissed', 'no');
 				if ($dismissed == 'yes') {

--- a/inc/TTBM_Woo_Installer.php
+++ b/inc/TTBM_Woo_Installer.php
@@ -59,6 +59,7 @@ if ( ! class_exists( 'TTBM_Woo_Installer' ) ) {
 			// WooCommerce is active → redirect immediately
 			if ( $this->is_woo_active() ) {
 				delete_transient( 'ttbm_plugin_activated' );
+				set_transient( 'ttbm_woo_just_activated', true, 300 );
 				wp_safe_redirect( admin_url( 'edit.php?post_type=ttbm_tour&page=ttbm_list' ) );
 				exit;
 			}
@@ -275,6 +276,9 @@ if ( ! class_exists( 'TTBM_Woo_Installer' ) ) {
 			if ( is_wp_error( $result ) ) {
 				wp_send_json_error( array( 'message' => $result->get_error_message() ) );
 			}
+
+			// Signal the demo import popup to auto-show on the next page load (tour list)
+			set_transient( 'ttbm_woo_just_activated', true, 300 );
 
 			wp_send_json_success( array( 'message' => __( 'WooCommerce activated successfully!', 'tour-booking-manager' ) ) );
 		}


### PR DESCRIPTION
## Problem
After activating WooCommerce via the installer popup and being redirected to the tour list page, the demo import popup was not appearing automatically.

## Root Cause (two-part)

1. TTBM_Dummy_Import::is_eligible() had no WooCommerce active check. This caused the demo import popup to render on the very first admin page load — the same page where the WooCommerce installer popup was showing. If the user dismissed the demo popup at that point ("No, Skip"), the option ttbm_dummy_import_dismissed was set to 'yes', permanently suppressing auto-show on all future page loads, including the tour list after WooCommerce was activated.

2. No signal existed to force-show the demo popup after WooCommerce was activated via AJAX. The auto-show logic relied solely on ttbm_dummy_import_dismissed being 'no', which could already be 'yes' due to issue #1.

## Fix

inc/TTBM_Woo_Installer.php
- ajax_activate_woocommerce(): set transient ttbm_woo_just_activated (TTL 300s) immediately after WooCommerce is activated via AJAX.
- handle_activation_redirect(): also set the same transient before the PHP redirect that fires when WooCommerce is already active at plugin activation time.

admin/TTBM_Dummy_Import.php
- is_eligible(): added WooCommerce active check at the top. The demo import popup will now only render when WooCommerce is active, preventing it from appearing (and potentially being dismissed) on the woo-installer screen.
- should_auto_show_popup(): added transient check for ttbm_woo_just_activated. If the transient is present, the popup is force-shown and the transient is deleted — this ensures the demo popup appears automatically on the tour list page after WooCommerce activation, even if it was previously dismissed.

## Flow After Fix

1. Plugin activated — WooCommerce not active
2. WooCommerce installer popup shows (demo popup suppressed — Woo not active)
3. User installs/activates WooCommerce via installer popup
4. ajax_activate_woocommerce sets ttbm_woo_just_activated transient
5. JS redirects to tour list (edit.php?post_type=ttbm_tour&page=ttbm_list)
6. On tour list page: transient found → demo import popup auto-shows