### PR TITLE
feat: add wishlist functionality with login modal and My Account tab

### DIFF
--- a/admin/TTBM_Admin_Tour_List.php
+++ b/admin/TTBM_Admin_Tour_List.php
@@ -201,6 +201,7 @@
                             <button data-target="ttbm_trvel_lists_features" data-tab-type="Add New Feature"><span class="icon-wrap"><i class="mi mi-list"></i><?php  esc_html_e('Features','tour-booking-manager'); ?></span></button>
                             <button data-target="ttbm_trvel_lists_tag" data-tab-type="Add New Tag"><span class="icon-wrap"><i class="mi mi-tags"></i> <?php  esc_html_e('Tags','tour-booking-manager'); ?></span></button>
                             <button data-target="ttbm_trvel_lists_activities" data-tab-type="Add New Activities"><span class="icon-wrap"><i class="mi mi-practice"></i><?php  esc_html_e('Activities','tour-booking-manager'); ?></span></button>
+                            <?php do_action('ttbm_travel_lists_tab_button', $label); ?>
                         </div>
                         
                         <div class="ttbm-tour-dashboard-content">

--- a/admin/TTBM_Admin_Wishlist.php
+++ b/admin/TTBM_Admin_Wishlist.php
@@ -1,0 +1,368 @@
+<?php
+/**
+ * Admin Wishlist Page
+ * Shows which customers wishlisted which tours with user details.
+ * @package Tour Booking Manager
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+if ( ! class_exists( 'TTBM_Admin_Wishlist' ) ) {
+	class TTBM_Admin_Wishlist {
+
+		public function __construct() {
+			add_action( 'admin_menu', array( $this, 'add_admin_menu' ) );
+			add_action( 'wp_ajax_ttbm_admin_wishlist_search', array( $this, 'ajax_search' ) );
+		}
+
+		// ─── Admin Menu ──────────────────────────────────────────
+		public function add_admin_menu() {
+			$label = TTBM_Function::get_name();
+			add_submenu_page(
+				'edit.php?post_type=ttbm_tour',
+				$label . ' ' . esc_html__( 'Wishlist', 'tour-booking-manager' ),
+				$label . ' ' . esc_html__( 'Wishlist', 'tour-booking-manager' ),
+				'manage_options',
+				'ttbm_wishlist_admin',
+				array( $this, 'render_page' )
+			);
+		}
+
+		// ─── AJAX Search ─────────────────────────────────────────
+		public function ajax_search() {
+			if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'ttbm_admin_nonce' ) ) {
+				wp_send_json_error( array( 'message' => 'Invalid nonce' ) );
+			}
+			if ( ! current_user_can( 'manage_options' ) ) {
+				wp_send_json_error( array( 'message' => 'Unauthorized' ), 403 );
+			}
+
+			$search   = isset( $_POST['search'] ) ? sanitize_text_field( wp_unslash( $_POST['search'] ) ) : '';
+			$tour_id  = isset( $_POST['tour_id'] ) ? absint( $_POST['tour_id'] ) : 0;
+			$paged    = isset( $_POST['paged'] ) ? absint( $_POST['paged'] ) : 1;
+			$per_page = 20;
+
+			$results = $this->get_wishlist_data( $search, $tour_id, $paged, $per_page );
+
+			wp_send_json_success( $results );
+		}
+
+		// ─── Data Gathering ───────────────────────────────────────
+		private function get_wishlist_data( $search = '', $tour_id = 0, $paged = 1, $per_page = 20 ) {
+			global $wpdb;
+
+			$meta_key = 'ttbm_wishlist';
+
+			// Get all users who have wishlist data
+			$user_ids = $wpdb->get_col( $wpdb->prepare(
+				"SELECT user_id FROM {$wpdb->usermeta} WHERE meta_key = %s",
+				$meta_key
+			) );
+
+			$rows = array();
+
+			if ( ! empty( $user_ids ) ) {
+				foreach ( $user_ids as $uid ) {
+					$list = get_user_meta( $uid, $meta_key, true );
+					if ( ! is_array( $list ) || empty( $list ) ) {
+						continue;
+					}
+					$user = get_userdata( $uid );
+					if ( ! $user ) {
+						continue;
+					}
+					// Filter by search term (name or email)
+					if ( $search ) {
+						$match = false;
+						$haystack = strtolower( $user->display_name . ' ' . $user->user_email . ' ' . $user->first_name . ' ' . $user->last_name );
+						if ( strpos( $haystack, strtolower( $search ) ) !== false ) {
+							$match = true;
+						}
+						if ( ! $match ) {
+							continue;
+						}
+					}
+
+					foreach ( $list as $tid ) {
+						// Filter by specific tour
+						if ( $tour_id && $tid !== $tour_id ) {
+							continue;
+						}
+						$tour = get_post( $tid );
+						if ( ! $tour ) {
+							continue;
+						}
+
+						// User address details
+						$billing_first = get_user_meta( $uid, 'billing_first_name', true );
+						$billing_last  = get_user_meta( $uid, 'billing_last_name', true );
+						$billing_phone = get_user_meta( $uid, 'billing_phone', true );
+						$billing_city  = get_user_meta( $uid, 'billing_city', true );
+						$billing_state = get_user_meta( $uid, 'billing_state', true );
+						$billing_country = get_user_meta( $uid, 'billing_country', true );
+						$billing_postcode = get_user_meta( $uid, 'billing_postcode', true );
+						$billing_address_1 = get_user_meta( $uid, 'billing_address_1', true );
+						$billing_address_2 = get_user_meta( $uid, 'billing_address_2', true );
+
+						$rows[] = array(
+							'user_id'         => $uid,
+							'display_name'    => $user->display_name,
+							'user_email'      => $user->user_email,
+							'first_name'      => $user->first_name,
+							'last_name'       => $user->last_name,
+							'billing_first'   => $billing_first ?: $user->first_name,
+							'billing_last'    => $billing_last ?: $user->last_name,
+							'billing_phone'   => $billing_phone,
+							'billing_city'    => $billing_city,
+							'billing_state'   => $billing_state,
+							'billing_country' => $billing_country,
+							'billing_postcode' => $billing_postcode,
+							'billing_address' => trim( $billing_address_1 . ' ' . $billing_address_2 ),
+							'tour_id'         => $tid,
+							'tour_title'      => $tour->post_title,
+							'tour_status'     => $tour->post_status,
+							'tour_edit_link'  => admin_url( 'post.php?post=' . $tid . '&action=edit' ),
+						);
+					}
+				}
+			}
+
+			$total      = count( $rows );
+			$total_pages = max( 1, (int) ceil( $total / $per_page ) );
+			$offset      = ( $paged - 1 ) * $per_page;
+			$rows        = array_slice( $rows, $offset, $per_page );
+
+			// Get tours list for filter dropdown
+			$tours = get_posts( array(
+				'post_type'      => 'ttbm_tour',
+				'post_status'     => array( 'publish', 'draft', 'pending' ),
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'orderby'        => 'title',
+				'order'          => 'ASC',
+			) );
+
+			$tour_options = array();
+			foreach ( $tours as $tid ) {
+				$tour_options[] = array(
+					'id'    => $tid,
+					'title' => get_the_title( $tid ),
+				);
+			}
+
+			return array(
+				'rows'          => $rows,
+				'total'         => $total,
+				'paged'         => $paged,
+				'per_page'      => $per_page,
+				'total_pages'   => $total_pages,
+				'tour_options'  => $tour_options,
+			);
+		}
+
+		// ─── Render Page ──────────────────────────────────────────
+		public function render_page() {
+			if ( ! current_user_can( 'manage_options' ) ) {
+				return;
+			}
+
+			$search   = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
+			$tour_id  = isset( $_GET['tour_id'] ) ? absint( $_GET['tour_id'] ) : 0;
+			$paged    = isset( $_GET['paged'] ) ? absint( $_GET['paged'] ) : 1;
+			$per_page = 20;
+
+			$data = $this->get_wishlist_data( $search, $tour_id, $paged, $per_page );
+
+			$label = TTBM_Function::get_name();
+			?>
+			<div class="wrap ttbm-wishlist-admin-wrap">
+				<h1 class="wp-heading-inline">
+					<span class="dashicons dashicons-heart" style="color:#e84c6a;margin-right:6px;"></span>
+					<?php echo esc_html( $label ); ?> <?php esc_html_e( 'Wishlist', 'tour-booking-manager' ); ?>
+				</h1>
+				<span class="ttbm-wishlist-count"><?php printf( esc_html__( '(%d entries)', 'tour-booking-manager' ), $data['total'] ); ?></span>
+				<hr class="wp-header-end">
+
+				<!-- Filters -->
+				<div class="ttbm-wishlist-filters">
+					<form method="get" class="ttbm-wishlist-filter-form">
+						<input type="hidden" name="post_type" value="ttbm_tour">
+						<input type="hidden" name="page" value="ttbm_wishlist_admin">
+						<div class="ttbm-filter-row">
+							<input type="search" name="s" value="<?php echo esc_attr( $search ); ?>" placeholder="<?php esc_attr_e( 'Search by name or email…', 'tour-booking-manager' ); ?>" class="ttbm-filter-input">
+							<select name="tour_id" class="ttbm-filter-select">
+								<option value="0"><?php esc_html_e( 'All Tours', 'tour-booking-manager' ); ?></option>
+								<?php foreach ( $data['tour_options'] as $topt ) : ?>
+									<option value="<?php echo esc_attr( $topt['id'] ); ?>" <?php selected( $tour_id, $topt['id'] ); ?>><?php echo esc_html( $topt['title'] ); ?></option>
+								<?php endforeach; ?>
+							</select>
+							<input type="submit" class="button button-primary" value="<?php esc_attr_e( 'Filter', 'tour-booking-manager' ); ?>">
+							<?php if ( $search || $tour_id ) : ?>
+								<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=ttbm_tour&page=ttbm_wishlist_admin' ) ); ?>" class="button"><?php esc_html_e( 'Reset', 'tour-booking-manager' ); ?></a>
+							<?php endif; ?>
+						</div>
+					</form>
+				</div>
+
+				<!-- Table -->
+				<?php if ( ! empty( $data['rows'] ) ) : ?>
+				<table class="wp-list-table widefat fixed striped ttbm-wishlist-table">
+					<thead>
+						<tr>
+							<th class="column-customer"><?php esc_html_e( 'Customer', 'tour-booking-manager' ); ?></th>
+							<th class="column-email"><?php esc_html_e( 'Email', 'tour-booking-manager' ); ?></th>
+							<th class="column-phone"><?php esc_html_e( 'Phone', 'tour-booking-manager' ); ?></th>
+							<th class="column-address"><?php esc_html_e( 'Address', 'tour-booking-manager' ); ?></th>
+							<th class="column-city"><?php esc_html_e( 'City', 'tour-booking-manager' ); ?></th>
+							<th class="column-state"><?php esc_html_e( 'State', 'tour-booking-manager' ); ?></th>
+							<th class="column-country"><?php esc_html_e( 'Country', 'tour-booking-manager' ); ?></th>
+							<th class="column-postcode"><?php esc_html_e( 'Postcode', 'tour-booking-manager' ); ?></th>
+							<th class="column-tour"><?php esc_html_e( 'Tour', 'tour-booking-manager' ); ?></th>
+							<th class="column-status"><?php esc_html_e( 'Tour Status', 'tour-booking-manager' ); ?></th>
+						</tr>
+					</thead>
+					<tbody>
+						<?php foreach ( $data['rows'] as $row ) :
+							$country_name = '';
+							if ( $row['billing_country'] && function_exists( 'WC' ) ) {
+								$countries = WC()->countries->get_countries();
+								$country_name = isset( $countries[ $row['billing_country'] ] ) ? $countries[ $row['billing_country'] ] : $row['billing_country'];
+							} else {
+								$country_name = $row['billing_country'];
+							}
+						?>
+						<tr>
+							<td class="column-customer">
+								<a href="<?php echo esc_url( admin_url( 'user-edit.php?user_id=' . $row['user_id'] ) ); ?>">
+									<strong><?php echo esc_html( $row['billing_first'] . ' ' . $row['billing_last'] ); ?></strong>
+								</a>
+								<?php if ( $row['billing_first'] !== $row['first_name'] && $row['first_name'] ) : ?>
+									<br><small class="ttbm-subtle"><?php echo esc_html( '@' . $row['display_name'] ); ?></small>
+								<?php endif; ?>
+							</td>
+							<td class="column-email">
+								<a href="mailto:<?php echo esc_attr( $row['user_email'] ); ?>"><?php echo esc_html( $row['user_email'] ); ?></a>
+							</td>
+							<td class="column-phone"><?php echo esc_html( $row['billing_phone'] ); ?></td>
+							<td class="column-address"><?php echo esc_html( $row['billing_address'] ); ?></td>
+							<td class="column-city"><?php echo esc_html( $row['billing_city'] ); ?></td>
+							<td class="column-state"><?php echo esc_html( $row['billing_state'] ); ?></td>
+							<td class="column-country"><?php echo esc_html( $country_name ); ?></td>
+							<td class="column-postcode"><?php echo esc_html( $row['billing_postcode'] ); ?></td>
+							<td class="column-tour">
+								<a href="<?php echo esc_url( $row['tour_edit_link'] ); ?>">
+									<?php echo esc_html( $row['tour_title'] ); ?>
+								</a>
+							</td>
+							<td class="column-status">
+								<?php
+								$status_labels = array(
+									'publish' => '<span class="ttbm-status ttbm-status-publish">' . esc_html__( 'Published', 'tour-booking-manager' ) . '</span>',
+									'draft'   => '<span class="ttbm-status ttbm-status-draft">' . esc_html__( 'Draft', 'tour-booking-manager' ) . '</span>',
+									'pending' => '<span class="ttbm-status ttbm-status-pending">' . esc_html__( 'Pending', 'tour-booking-manager' ) . '</span>',
+								);
+								echo isset( $status_labels[ $row['tour_status'] ] ) ? $status_labels[ $row['tour_status'] ] : esc_html( ucfirst( $row['tour_status'] ) );
+								?>
+							</td>
+						</tr>
+						<?php endforeach; ?>
+					</tbody>
+				</table>
+
+				<!-- Pagination -->
+				<?php if ( $data['total_pages'] > 1 ) : ?>
+				<div class="tablenav bottom">
+					<div class="tablenav-pages">
+						<span class="displaying-num"><?php printf( esc_html__( '%d items', 'tour-booking-manager' ), $data['total'] ); ?></span>
+						<span class="pagination-links">
+							<?php
+							$base_url = admin_url( 'edit.php?post_type=ttbm_tour&page=ttbm_wishlist_admin' );
+							if ( $search ) {
+								$base_url = add_query_arg( 's', urlencode( $search ), $base_url );
+							}
+							if ( $tour_id ) {
+								$base_url = add_query_arg( 'tour_id', $tour_id, $base_url );
+							}
+
+							if ( $paged > 1 ) {
+								echo '<a class="button first-page" href="' . esc_url( add_query_arg( 'paged', 1, $base_url ) ) . '"><span aria-hidden="true">&laquo;</span></a> ';
+								echo '<a class="button prev-page" href="' . esc_url( add_query_arg( 'paged', $paged - 1, $base_url ) ) . '"><span aria-hidden="true">&lsaquo;</span></a> ';
+							} else {
+								echo '<span class="button disabled">&laquo;</span> ';
+								echo '<span class="button disabled">&lsaquo;</span> ';
+							}
+
+							echo '<span class="paging-input">' . esc_html( $paged ) . ' of <span class="total-pages">' . esc_html( $data['total_pages'] ) . '</span></span>';
+
+							if ( $paged < $data['total_pages'] ) {
+								echo ' <a class="button next-page" href="' . esc_url( add_query_arg( 'paged', $paged + 1, $base_url ) ) . '"><span aria-hidden="true">&rsaquo;</span></a>';
+								echo ' <a class="button last-page" href="' . esc_url( add_query_arg( 'paged', $data['total_pages'], $base_url ) ) . '"><span aria-hidden="true">&raquo;</span></a>';
+							} else {
+								echo ' <span class="button disabled">&rsaquo;</span>';
+								echo ' <span class="button disabled">&raquo;</span>';
+							}
+							?>
+						</span>
+					</div>
+				</div>
+				<?php endif; ?>
+
+				<?php else : ?>
+				<div class="ttbm-wishlist-empty-state">
+					<span class="dashicons dashicons-heart"></span>
+					<h3><?php esc_html_e( 'No wishlists found', 'tour-booking-manager' ); ?></h3>
+					<p><?php esc_html_e( 'No customers have added tours to their wishlist yet.', 'tour-booking-manager' ); ?></p>
+				</div>
+				<?php endif; ?>
+			</div>
+
+			<style>
+			.ttbm-wishlist-admin-wrap { margin-top: 10px; }
+			.ttbm-wishlist-admin-wrap .wp-heading-inline { display: inline-flex; align-items: center; gap: 4px; }
+			.ttbm-wishlist-count { font-size: 14px; color: #666; margin-left: 8px; }
+			.ttbm-wishlist-filters { background: #fff; border: 1px solid #ccd0d4; border-radius: 4px; padding: 12px 16px; margin: 16px 0; }
+			.ttbm-filter-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+			.ttbm-filter-input { min-width: 240px; }
+			.ttbm-filter-select { min-width: 200px; }
+			.ttbm-wishlist-table th.column-customer,
+			.ttbm-wishlist-table td.column-customer { width: 14%; }
+			.ttbm-wishlist-table th.column-email,
+			.ttbm-wishlist-table td.column-email { width: 14%; }
+			.ttbm-wishlist-table th.column-phone,
+			.ttbm-wishlist-table td.column-phone { width: 9%; }
+			.ttbm-wishlist-table th.column-address,
+			.ttbm-wishlist-table td.column-address { width: 12%; }
+			.ttbm-wishlist-table th.column-city,
+			.ttbm-wishlist-table td.column-city { width: 7%; }
+			.ttbm-wishlist-table th.column-state,
+			.ttbm-wishlist-table td.column-state { width: 7%; }
+			.ttbm-wishlist-table th.column-country,
+			.ttbm-wishlist-table td.column-country { width: 8%; }
+			.ttbm-wishlist-table th.column-postcode,
+			.ttbm-wishlist-table td.column-postcode { width: 6%; }
+			.ttbm-wishlist-table th.column-tour,
+			.ttbm-wishlist-table td.column-tour { width: 15%; }
+			.ttbm-wishlist-table th.column-status,
+			.ttbm-wishlist-table td.column-status { width: 8%; }
+			.ttbm-wishlist-table td { vertical-align: middle; }
+			.ttbm-wishlist-table td a { text-decoration: none; }
+			.ttbm-wishlist-table td a:hover { color: #6c47ff; }
+			.ttbm-subtle { color: #999; }
+			.ttbm-status { display: inline-block; padding: 2px 8px; border-radius: 3px; font-size: 12px; font-weight: 500; }
+			.ttbm-status-publish { background: #d4edda; color: #155724; }
+			.ttbm-status-draft { background: #fff3cd; color: #856404; }
+			.ttbm-status-pending { background: #cce5ff; color: #004085; }
+			.ttbm-wishlist-empty-state { text-align: center; padding: 60px 20px; color: #888; }
+			.ttbm-wishlist-empty-state .dashicons { font-size: 48px; width: 48px; height: 48px; color: #ddd; }
+			.ttbm-wishlist-empty-state h3 { margin: 16px 0 4px; font-size: 18px; color: #555; }
+			.ttbm-wishlist-empty-state p { font-size: 14px; color: #888; }
+			@media (max-width: 782px) {
+				.ttbm-filter-row { flex-direction: column; align-items: stretch; }
+				.ttbm-filter-input, .ttbm-filter-select { width: 100%; min-width: 0; }
+			}
+			</style>
+			<?php
+		}
+	}
+	new TTBM_Admin_Wishlist();
+}

--- a/admin/TTBM_Admin_Wishlist.php
+++ b/admin/TTBM_Admin_Wishlist.php
@@ -52,6 +52,13 @@ if ( ! class_exists( 'TTBM_Admin_Wishlist' ) ) {
 		private function get_wishlist_data( $search = '', $tour_id = 0, $paged = 1, $per_page = 20 ) {
 			global $wpdb;
 
+			// Only get non-admin users who have a wishlist
+			$admin_ids = get_users( array(
+				'capability' => array( 'manage_options' ),
+				'fields'     => 'ID',
+			) );
+			$exclude = array_map( 'intval', (array) $admin_ids );
+
 			$user_ids = $wpdb->get_col( $wpdb->prepare(
 				"SELECT user_id FROM {$wpdb->usermeta} WHERE meta_key = %s",
 				'ttbm_wishlist'
@@ -61,6 +68,10 @@ if ( ! class_exists( 'TTBM_Admin_Wishlist' ) ) {
 
 			if ( ! empty( $user_ids ) ) {
 				foreach ( $user_ids as $uid ) {
+					// Skip admin users — only show real customers
+					if ( in_array( intval( $uid ), $exclude, true ) ) {
+						continue;
+					}
 					$list = get_user_meta( $uid, 'ttbm_wishlist', true );
 					if ( ! is_array( $list ) || empty( $list ) ) {
 						continue;

--- a/admin/TTBM_Admin_Wishlist.php
+++ b/admin/TTBM_Admin_Wishlist.php
@@ -1,7 +1,6 @@
 <?php
 /**
- * Admin Wishlist Page
- * Shows which customers wishlisted which tours with user details.
+ * Admin Wishlist — integrated as a tab in Tour List page.
  * @package Tour Booking Manager
  */
 if ( ! defined( 'ABSPATH' ) ) {
@@ -11,59 +10,58 @@ if ( ! class_exists( 'TTBM_Admin_Wishlist' ) ) {
 	class TTBM_Admin_Wishlist {
 
 		public function __construct() {
-			add_action( 'admin_menu', array( $this, 'add_admin_menu' ) );
-			add_action( 'wp_ajax_ttbm_admin_wishlist_search', array( $this, 'ajax_search' ) );
+			// Add wishlist tab button to the Tour List tab bar
+			add_action( 'ttbm_travel_lists_tab_button', array( $this, 'add_tab_button' ), 10, 1 );
+			// Add wishlist content panel inside the tab holder
+			add_action( 'ttbm_travel_lists_tab_display', array( $this, 'add_tab_content' ), 20, 3 );
+			// AJAX handler for filtering
+			add_action( 'wp_ajax_ttbm_wishlist_admin_data', array( $this, 'ajax_get_data' ) );
+			// Enqueue admin styles
+			add_action( 'admin_enqueue_scripts', array( $this, 'admin_styles' ) );
 		}
 
-		// ─── Admin Menu ──────────────────────────────────────────
-		public function add_admin_menu() {
-			$label = TTBM_Function::get_name();
-			add_submenu_page(
-				'edit.php?post_type=ttbm_tour',
-				$label . ' ' . esc_html__( 'Wishlist', 'tour-booking-manager' ),
-				$label . ' ' . esc_html__( 'Wishlist', 'tour-booking-manager' ),
-				'manage_options',
-				'ttbm_wishlist_admin',
-				array( $this, 'render_page' )
-			);
+		// ─── Tab Button ───────────────────────────────────────────
+		public function add_tab_button( $label ) {
+			?>
+			<button data-target="ttbm_trvel_lists_wishlist" data-tab-type="Wishlist">
+				<span class="icon-wrap"><i class="mi mi-heart"></i><?php esc_html_e( ' Wishlist', 'tour-booking-manager' ); ?></span>
+			</button>
+			<?php
 		}
 
-		// ─── AJAX Search ─────────────────────────────────────────
-		public function ajax_search() {
-			if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'ttbm_admin_nonce' ) ) {
-				wp_send_json_error( array( 'message' => 'Invalid nonce' ) );
+		// ─── Tab Content Panel ────────────────────────────────────
+		public function add_tab_content( $label, $analytics_Data, $posts_query ) {
+			$data = $this->get_wishlist_data();
+			?>
+			<div id="ttbm_trvel_lists_wishlist" class="ttbm_trvel_lists_content">
+				<?php $this->render_wishlist_table( $data ); ?>
+			</div>
+			<?php
+		}
+
+		// ─── Admin Styles ─────────────────────────────────────────
+		public function admin_styles( $hook ) {
+			if ( $hook !== 'ttbm_tour_page_ttbm_list' ) {
+				return;
 			}
-			if ( ! current_user_can( 'manage_options' ) ) {
-				wp_send_json_error( array( 'message' => 'Unauthorized' ), 403 );
-			}
-
-			$search   = isset( $_POST['search'] ) ? sanitize_text_field( wp_unslash( $_POST['search'] ) ) : '';
-			$tour_id  = isset( $_POST['tour_id'] ) ? absint( $_POST['tour_id'] ) : 0;
-			$paged    = isset( $_POST['paged'] ) ? absint( $_POST['paged'] ) : 1;
-			$per_page = 20;
-
-			$results = $this->get_wishlist_data( $search, $tour_id, $paged, $per_page );
-
-			wp_send_json_success( $results );
+			$ver = filemtime( TTBM_PLUGIN_DIR . '/admin/ttbm-wishlist-admin.css' );
+			wp_enqueue_style( 'ttbm-wishlist-admin', TTBM_PLUGIN_URL . '/admin/ttbm-wishlist-admin.css', array(), $ver );
 		}
 
 		// ─── Data Gathering ───────────────────────────────────────
 		private function get_wishlist_data( $search = '', $tour_id = 0, $paged = 1, $per_page = 20 ) {
 			global $wpdb;
 
-			$meta_key = 'ttbm_wishlist';
-
-			// Get all users who have wishlist data
 			$user_ids = $wpdb->get_col( $wpdb->prepare(
 				"SELECT user_id FROM {$wpdb->usermeta} WHERE meta_key = %s",
-				$meta_key
+				'ttbm_wishlist'
 			) );
 
 			$rows = array();
 
 			if ( ! empty( $user_ids ) ) {
 				foreach ( $user_ids as $uid ) {
-					$list = get_user_meta( $uid, $meta_key, true );
+					$list = get_user_meta( $uid, 'ttbm_wishlist', true );
 					if ( ! is_array( $list ) || empty( $list ) ) {
 						continue;
 					}
@@ -73,19 +71,14 @@ if ( ! class_exists( 'TTBM_Admin_Wishlist' ) ) {
 					}
 					// Filter by search term (name or email)
 					if ( $search ) {
-						$match = false;
 						$haystack = strtolower( $user->display_name . ' ' . $user->user_email . ' ' . $user->first_name . ' ' . $user->last_name );
-						if ( strpos( $haystack, strtolower( $search ) ) !== false ) {
-							$match = true;
-						}
-						if ( ! $match ) {
+						if ( strpos( $haystack, strtolower( $search ) ) === false ) {
 							continue;
 						}
 					}
 
 					foreach ( $list as $tid ) {
-						// Filter by specific tour
-						if ( $tour_id && $tid !== $tour_id ) {
+						if ( $tour_id && absint( $tid ) !== $tour_id ) {
 							continue;
 						}
 						$tour = get_post( $tid );
@@ -93,49 +86,37 @@ if ( ! class_exists( 'TTBM_Admin_Wishlist' ) ) {
 							continue;
 						}
 
-						// User address details
-						$billing_first = get_user_meta( $uid, 'billing_first_name', true );
-						$billing_last  = get_user_meta( $uid, 'billing_last_name', true );
-						$billing_phone = get_user_meta( $uid, 'billing_phone', true );
-						$billing_city  = get_user_meta( $uid, 'billing_city', true );
-						$billing_state = get_user_meta( $uid, 'billing_state', true );
-						$billing_country = get_user_meta( $uid, 'billing_country', true );
-						$billing_postcode = get_user_meta( $uid, 'billing_postcode', true );
-						$billing_address_1 = get_user_meta( $uid, 'billing_address_1', true );
-						$billing_address_2 = get_user_meta( $uid, 'billing_address_2', true );
-
 						$rows[] = array(
-							'user_id'         => $uid,
-							'display_name'    => $user->display_name,
-							'user_email'      => $user->user_email,
-							'first_name'      => $user->first_name,
-							'last_name'       => $user->last_name,
-							'billing_first'   => $billing_first ?: $user->first_name,
-							'billing_last'    => $billing_last ?: $user->last_name,
-							'billing_phone'   => $billing_phone,
-							'billing_city'    => $billing_city,
-							'billing_state'   => $billing_state,
-							'billing_country' => $billing_country,
-							'billing_postcode' => $billing_postcode,
-							'billing_address' => trim( $billing_address_1 . ' ' . $billing_address_2 ),
-							'tour_id'         => $tid,
-							'tour_title'      => $tour->post_title,
-							'tour_status'     => $tour->post_status,
-							'tour_edit_link'  => admin_url( 'post.php?post=' . $tid . '&action=edit' ),
+							'user_id'          => $uid,
+							'display_name'     => $user->display_name,
+							'user_email'       => $user->user_email,
+							'first_name'       => $user->first_name,
+							'last_name'        => $user->last_name,
+							'billing_first'    => get_user_meta( $uid, 'billing_first_name', true ) ?: $user->first_name,
+							'billing_last'     => get_user_meta( $uid, 'billing_last_name', true ) ?: $user->last_name,
+							'billing_phone'    => get_user_meta( $uid, 'billing_phone', true ),
+							'billing_city'     => get_user_meta( $uid, 'billing_city', true ),
+							'billing_state'    => get_user_meta( $uid, 'billing_state', true ),
+							'billing_country'  => get_user_meta( $uid, 'billing_country', true ),
+							'billing_postcode' => get_user_meta( $uid, 'billing_postcode', true ),
+							'billing_address'  => trim( get_user_meta( $uid, 'billing_address_1', true ) . ' ' . get_user_meta( $uid, 'billing_address_2', true ) ),
+							'tour_id'          => $tid,
+							'tour_title'       => $tour->post_title,
+							'tour_status'      => $tour->post_status,
+							'tour_edit_link'   => admin_url( 'post.php?post=' . $tid . '&action=edit' ),
 						);
 					}
 				}
 			}
 
-			$total      = count( $rows );
+			$total       = count( $rows );
 			$total_pages = max( 1, (int) ceil( $total / $per_page ) );
-			$offset      = ( $paged - 1 ) * $per_page;
-			$rows        = array_slice( $rows, $offset, $per_page );
+			$rows        = array_slice( $rows, ( $paged - 1 ) * $per_page, $per_page );
 
-			// Get tours list for filter dropdown
+			// Tours for dropdown filter
 			$tours = get_posts( array(
 				'post_type'      => 'ttbm_tour',
-				'post_status'     => array( 'publish', 'draft', 'pending' ),
+				'post_status'    => array( 'publish', 'draft', 'pending' ),
 				'posts_per_page' => -1,
 				'fields'         => 'ids',
 				'orderby'        => 'title',
@@ -151,74 +132,72 @@ if ( ! class_exists( 'TTBM_Admin_Wishlist' ) ) {
 			}
 
 			return array(
-				'rows'          => $rows,
-				'total'         => $total,
-				'paged'         => $paged,
-				'per_page'      => $per_page,
-				'total_pages'   => $total_pages,
-				'tour_options'  => $tour_options,
+				'rows'         => $rows,
+				'total'        => $total,
+				'paged'        => $paged,
+				'per_page'     => $per_page,
+				'total_pages'  => $total_pages,
+				'tour_options' => $tour_options,
 			);
 		}
 
-		// ─── Render Page ──────────────────────────────────────────
-		public function render_page() {
+		// ─── AJAX Data ─────────────────────────────────────────────
+		public function ajax_get_data() {
+			if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'ttbm_admin_nonce' ) ) {
+				wp_send_json_error( array( 'message' => 'Invalid nonce' ) );
+			}
 			if ( ! current_user_can( 'manage_options' ) ) {
-				return;
+				wp_send_json_error( array( 'message' => 'Unauthorized' ), 403 );
 			}
 
-			$search   = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
-			$tour_id  = isset( $_GET['tour_id'] ) ? absint( $_GET['tour_id'] ) : 0;
-			$paged    = isset( $_GET['paged'] ) ? absint( $_GET['paged'] ) : 1;
-			$per_page = 20;
+			$search  = isset( $_POST['search'] ) ? sanitize_text_field( wp_unslash( $_POST['search'] ) ) : '';
+			$tour_id = isset( $_POST['tour_id'] ) ? absint( $_POST['tour_id'] ) : 0;
+			$paged   = isset( $_POST['paged'] ) ? absint( $_POST['paged'] ) : 1;
 
-			$data = $this->get_wishlist_data( $search, $tour_id, $paged, $per_page );
+			$data = $this->get_wishlist_data( $search, $tour_id, $paged );
 
-			$label = TTBM_Function::get_name();
+			ob_start();
+			$this->render_wishlist_table( $data );
+			$html = ob_get_clean();
+
+			wp_send_json_success( array( 'html' => $html, 'total' => $data['total'] ) );
+		}
+
+		// ─── Render Table ──────────────────────────────────────────
+		private function render_wishlist_table( $data ) {
+			$search  = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
+			$tour_id = isset( $_GET['tour_id'] ) ? absint( $_GET['tour_id'] ) : 0;
 			?>
-			<div class="wrap ttbm-wishlist-admin-wrap">
-				<h1 class="wp-heading-inline">
-					<span class="dashicons dashicons-heart" style="color:#e84c6a;margin-right:6px;"></span>
-					<?php echo esc_html( $label ); ?> <?php esc_html_e( 'Wishlist', 'tour-booking-manager' ); ?>
-				</h1>
-				<span class="ttbm-wishlist-count"><?php printf( esc_html__( '(%d entries)', 'tour-booking-manager' ), $data['total'] ); ?></span>
-				<hr class="wp-header-end">
-
-				<!-- Filters -->
-				<div class="ttbm-wishlist-filters">
-					<form method="get" class="ttbm-wishlist-filter-form">
-						<input type="hidden" name="post_type" value="ttbm_tour">
-						<input type="hidden" name="page" value="ttbm_wishlist_admin">
-						<div class="ttbm-filter-row">
-							<input type="search" name="s" value="<?php echo esc_attr( $search ); ?>" placeholder="<?php esc_attr_e( 'Search by name or email…', 'tour-booking-manager' ); ?>" class="ttbm-filter-input">
-							<select name="tour_id" class="ttbm-filter-select">
-								<option value="0"><?php esc_html_e( 'All Tours', 'tour-booking-manager' ); ?></option>
-								<?php foreach ( $data['tour_options'] as $topt ) : ?>
-									<option value="<?php echo esc_attr( $topt['id'] ); ?>" <?php selected( $tour_id, $topt['id'] ); ?>><?php echo esc_html( $topt['title'] ); ?></option>
-								<?php endforeach; ?>
-							</select>
-							<input type="submit" class="button button-primary" value="<?php esc_attr_e( 'Filter', 'tour-booking-manager' ); ?>">
-							<?php if ( $search || $tour_id ) : ?>
-								<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=ttbm_tour&page=ttbm_wishlist_admin' ) ); ?>" class="button"><?php esc_html_e( 'Reset', 'tour-booking-manager' ); ?></a>
-							<?php endif; ?>
-						</div>
-					</form>
+			<div class="ttbm-wishlist-admin-wrap">
+				<div class="ttbm-wishlist-header">
+					<h2><i class="mi mi-heart"></i> <?php esc_html_e( 'Customer Wishlists', 'tour-booking-manager' ); ?> <span class="ttbm-wishlist-count">(<?php echo esc_html( $data['total'] ); ?>)</span></h2>
 				</div>
 
-				<!-- Table -->
+				<div class="ttbm-wishlist-filters">
+					<input type="text" id="ttbm-wishlist-search" placeholder="<?php esc_attr_e( 'Search by name or email…', 'tour-booking-manager' ); ?>" value="" class="ttbm-wishlist-filter-input">
+					<select id="ttbm-wishlist-tour-filter" class="ttbm-wishlist-filter-select">
+						<option value="0"><?php esc_html_e( 'All Tours', 'tour-booking-manager' ); ?></option>
+						<?php foreach ( $data['tour_options'] as $topt ) : ?>
+							<option value="<?php echo esc_attr( $topt['id'] ); ?>"><?php echo esc_html( $topt['title'] ); ?></option>
+						<?php endforeach; ?>
+					</select>
+					<button type="button" id="ttbm-wishlist-filter-btn" class="button button-primary"><i class="fas fa-search"></i> <?php esc_html_e( 'Filter', 'tour-booking-manager' ); ?></button>
+					<button type="button" id="ttbm-wishlist-reset-btn" class="button"><?php esc_html_e( 'Reset', 'tour-booking-manager' ); ?></button>
+				</div>
+
 				<?php if ( ! empty( $data['rows'] ) ) : ?>
 				<table class="wp-list-table widefat fixed striped ttbm-wishlist-table">
 					<thead>
 						<tr>
-							<th class="column-customer"><?php esc_html_e( 'Customer', 'tour-booking-manager' ); ?></th>
-							<th class="column-email"><?php esc_html_e( 'Email', 'tour-booking-manager' ); ?></th>
-							<th class="column-phone"><?php esc_html_e( 'Phone', 'tour-booking-manager' ); ?></th>
-							<th class="column-address"><?php esc_html_e( 'Address', 'tour-booking-manager' ); ?></th>
-							<th class="column-city"><?php esc_html_e( 'City', 'tour-booking-manager' ); ?></th>
-							<th class="column-state"><?php esc_html_e( 'State', 'tour-booking-manager' ); ?></th>
-							<th class="column-country"><?php esc_html_e( 'Country', 'tour-booking-manager' ); ?></th>
-							<th class="column-postcode"><?php esc_html_e( 'Postcode', 'tour-booking-manager' ); ?></th>
-							<th class="column-tour"><?php esc_html_e( 'Tour', 'tour-booking-manager' ); ?></th>
-							<th class="column-status"><?php esc_html_e( 'Tour Status', 'tour-booking-manager' ); ?></th>
+							<th><?php esc_html_e( 'Customer', 'tour-booking-manager' ); ?></th>
+							<th><?php esc_html_e( 'Email', 'tour-booking-manager' ); ?></th>
+							<th><?php esc_html_e( 'Phone', 'tour-booking-manager' ); ?></th>
+							<th><?php esc_html_e( 'Address', 'tour-booking-manager' ); ?></th>
+							<th><?php esc_html_e( 'City', 'tour-booking-manager' ); ?></th>
+							<th><?php esc_html_e( 'Country', 'tour-booking-manager' ); ?></th>
+							<th><?php esc_html_e( 'Postcode', 'tour-booking-manager' ); ?></th>
+							<th><?php esc_html_e( 'Tour', 'tour-booking-manager' ); ?></th>
+							<th><?php esc_html_e( 'Status', 'tour-booking-manager' ); ?></th>
 						</tr>
 					</thead>
 					<tbody>
@@ -232,36 +211,33 @@ if ( ! class_exists( 'TTBM_Admin_Wishlist' ) ) {
 							}
 						?>
 						<tr>
-							<td class="column-customer">
+							<td>
 								<a href="<?php echo esc_url( admin_url( 'user-edit.php?user_id=' . $row['user_id'] ) ); ?>">
 									<strong><?php echo esc_html( $row['billing_first'] . ' ' . $row['billing_last'] ); ?></strong>
 								</a>
-								<?php if ( $row['billing_first'] !== $row['first_name'] && $row['first_name'] ) : ?>
+								<?php if ( $row['display_name'] !== trim( $row['billing_first'] . ' ' . $row['billing_last'] ) ) : ?>
 									<br><small class="ttbm-subtle"><?php echo esc_html( '@' . $row['display_name'] ); ?></small>
 								<?php endif; ?>
 							</td>
-							<td class="column-email">
-								<a href="mailto:<?php echo esc_attr( $row['user_email'] ); ?>"><?php echo esc_html( $row['user_email'] ); ?></a>
-							</td>
-							<td class="column-phone"><?php echo esc_html( $row['billing_phone'] ); ?></td>
-							<td class="column-address"><?php echo esc_html( $row['billing_address'] ); ?></td>
-							<td class="column-city"><?php echo esc_html( $row['billing_city'] ); ?></td>
-							<td class="column-state"><?php echo esc_html( $row['billing_state'] ); ?></td>
-							<td class="column-country"><?php echo esc_html( $country_name ); ?></td>
-							<td class="column-postcode"><?php echo esc_html( $row['billing_postcode'] ); ?></td>
-							<td class="column-tour">
-								<a href="<?php echo esc_url( $row['tour_edit_link'] ); ?>">
-									<?php echo esc_html( $row['tour_title'] ); ?>
-								</a>
-							</td>
-							<td class="column-status">
+							<td><a href="mailto:<?php echo esc_attr( $row['user_email'] ); ?>"><?php echo esc_html( $row['user_email'] ); ?></a></td>
+							<td><?php echo esc_html( $row['billing_phone'] ); ?></td>
+							<td><?php echo esc_html( $row['billing_address'] ); ?></td>
+							<td><?php echo esc_html( $row['billing_city'] ); ?></td>
+							<td><?php echo esc_html( $country_name ); ?></td>
+							<td><?php echo esc_html( $row['billing_postcode'] ); ?></td>
+							<td><a href="<?php echo esc_url( $row['tour_edit_link'] ); ?>"><?php echo esc_html( $row['tour_title'] ); ?></a></td>
+							<td>
 								<?php
-								$status_labels = array(
-									'publish' => '<span class="ttbm-status ttbm-status-publish">' . esc_html__( 'Published', 'tour-booking-manager' ) . '</span>',
-									'draft'   => '<span class="ttbm-status ttbm-status-draft">' . esc_html__( 'Draft', 'tour-booking-manager' ) . '</span>',
-									'pending' => '<span class="ttbm-status ttbm-status-pending">' . esc_html__( 'Pending', 'tour-booking-manager' ) . '</span>',
+								$status_map = array(
+									'publish' => array( 'ttbm-status-publish', __( 'Published', 'tour-booking-manager' ) ),
+									'draft'   => array( 'ttbm-status-draft',   __( 'Draft', 'tour-booking-manager' ) ),
+									'pending' => array( 'ttbm-status-pending', __( 'Pending', 'tour-booking-manager' ) ),
 								);
-								echo isset( $status_labels[ $row['tour_status'] ] ) ? $status_labels[ $row['tour_status'] ] : esc_html( ucfirst( $row['tour_status'] ) );
+								if ( isset( $status_map[ $row['tour_status'] ] ) ) {
+									echo '<span class="ttbm-status ' . esc_attr( $status_map[ $row['tour_status'] ][0] ) . '">' . esc_html( $status_map[ $row['tour_status'] ][1] ) . '</span>';
+								} else {
+									echo esc_html( ucfirst( $row['tour_status'] ) );
+								}
 								?>
 							</td>
 						</tr>
@@ -269,39 +245,26 @@ if ( ! class_exists( 'TTBM_Admin_Wishlist' ) ) {
 					</tbody>
 				</table>
 
-				<!-- Pagination -->
 				<?php if ( $data['total_pages'] > 1 ) : ?>
-				<div class="tablenav bottom">
+				<div class="ttbm-wishlist-pagination tablenav">
 					<div class="tablenav-pages">
 						<span class="displaying-num"><?php printf( esc_html__( '%d items', 'tour-booking-manager' ), $data['total'] ); ?></span>
-						<span class="pagination-links">
-							<?php
-							$base_url = admin_url( 'edit.php?post_type=ttbm_tour&page=ttbm_wishlist_admin' );
-							if ( $search ) {
-								$base_url = add_query_arg( 's', urlencode( $search ), $base_url );
-							}
-							if ( $tour_id ) {
-								$base_url = add_query_arg( 'tour_id', $tour_id, $base_url );
-							}
-
-							if ( $paged > 1 ) {
-								echo '<a class="button first-page" href="' . esc_url( add_query_arg( 'paged', 1, $base_url ) ) . '"><span aria-hidden="true">&laquo;</span></a> ';
-								echo '<a class="button prev-page" href="' . esc_url( add_query_arg( 'paged', $paged - 1, $base_url ) ) . '"><span aria-hidden="true">&lsaquo;</span></a> ';
-							} else {
-								echo '<span class="button disabled">&laquo;</span> ';
-								echo '<span class="button disabled">&lsaquo;</span> ';
-							}
-
-							echo '<span class="paging-input">' . esc_html( $paged ) . ' of <span class="total-pages">' . esc_html( $data['total_pages'] ) . '</span></span>';
-
-							if ( $paged < $data['total_pages'] ) {
-								echo ' <a class="button next-page" href="' . esc_url( add_query_arg( 'paged', $paged + 1, $base_url ) ) . '"><span aria-hidden="true">&rsaquo;</span></a>';
-								echo ' <a class="button last-page" href="' . esc_url( add_query_arg( 'paged', $data['total_pages'], $base_url ) ) . '"><span aria-hidden="true">&raquo;</span></a>';
-							} else {
-								echo ' <span class="button disabled">&rsaquo;</span>';
-								echo ' <span class="button disabled">&raquo;</span>';
-							}
-							?>
+						<span class="pagination-links" id="ttbm-wishlist-pagination">
+							<?php if ( $data['paged'] > 1 ) : ?>
+								<button type="button" class="button first-page" data-page="1">&laquo;</button>
+								<button type="button" class="button prev-page" data-page="<?php echo esc_attr( $data['paged'] - 1 ); ?>">&lsaquo;</button>
+							<?php else : ?>
+								<span class="button disabled">&laquo;</span>
+								<span class="button disabled">&lsaquo;</span>
+							<?php endif; ?>
+							<span class="paging-input"><span class="current-page"><?php echo esc_html( $data['paged'] ); ?></span> of <span class="total-pages"><?php echo esc_html( $data['total_pages'] ); ?></span></span>
+							<?php if ( $data['paged'] < $data['total_pages'] ) : ?>
+								<button type="button" class="button next-page" data-page="<?php echo esc_attr( $data['paged'] + 1 ); ?>">&rsaquo;</button>
+								<button type="button" class="button last-page" data-page="<?php echo esc_attr( $data['total_pages'] ); ?>">&raquo;</button>
+							<?php else : ?>
+								<span class="button disabled">&rsaquo;</span>
+								<span class="button disabled">&raquo;</span>
+							<?php endif; ?>
 						</span>
 					</div>
 				</div>
@@ -309,58 +272,12 @@ if ( ! class_exists( 'TTBM_Admin_Wishlist' ) ) {
 
 				<?php else : ?>
 				<div class="ttbm-wishlist-empty-state">
-					<span class="dashicons dashicons-heart"></span>
+					<i class="mi mi-heart" style="font-size:48px;color:#ddd;"></i>
 					<h3><?php esc_html_e( 'No wishlists found', 'tour-booking-manager' ); ?></h3>
 					<p><?php esc_html_e( 'No customers have added tours to their wishlist yet.', 'tour-booking-manager' ); ?></p>
 				</div>
 				<?php endif; ?>
 			</div>
-
-			<style>
-			.ttbm-wishlist-admin-wrap { margin-top: 10px; }
-			.ttbm-wishlist-admin-wrap .wp-heading-inline { display: inline-flex; align-items: center; gap: 4px; }
-			.ttbm-wishlist-count { font-size: 14px; color: #666; margin-left: 8px; }
-			.ttbm-wishlist-filters { background: #fff; border: 1px solid #ccd0d4; border-radius: 4px; padding: 12px 16px; margin: 16px 0; }
-			.ttbm-filter-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-			.ttbm-filter-input { min-width: 240px; }
-			.ttbm-filter-select { min-width: 200px; }
-			.ttbm-wishlist-table th.column-customer,
-			.ttbm-wishlist-table td.column-customer { width: 14%; }
-			.ttbm-wishlist-table th.column-email,
-			.ttbm-wishlist-table td.column-email { width: 14%; }
-			.ttbm-wishlist-table th.column-phone,
-			.ttbm-wishlist-table td.column-phone { width: 9%; }
-			.ttbm-wishlist-table th.column-address,
-			.ttbm-wishlist-table td.column-address { width: 12%; }
-			.ttbm-wishlist-table th.column-city,
-			.ttbm-wishlist-table td.column-city { width: 7%; }
-			.ttbm-wishlist-table th.column-state,
-			.ttbm-wishlist-table td.column-state { width: 7%; }
-			.ttbm-wishlist-table th.column-country,
-			.ttbm-wishlist-table td.column-country { width: 8%; }
-			.ttbm-wishlist-table th.column-postcode,
-			.ttbm-wishlist-table td.column-postcode { width: 6%; }
-			.ttbm-wishlist-table th.column-tour,
-			.ttbm-wishlist-table td.column-tour { width: 15%; }
-			.ttbm-wishlist-table th.column-status,
-			.ttbm-wishlist-table td.column-status { width: 8%; }
-			.ttbm-wishlist-table td { vertical-align: middle; }
-			.ttbm-wishlist-table td a { text-decoration: none; }
-			.ttbm-wishlist-table td a:hover { color: #6c47ff; }
-			.ttbm-subtle { color: #999; }
-			.ttbm-status { display: inline-block; padding: 2px 8px; border-radius: 3px; font-size: 12px; font-weight: 500; }
-			.ttbm-status-publish { background: #d4edda; color: #155724; }
-			.ttbm-status-draft { background: #fff3cd; color: #856404; }
-			.ttbm-status-pending { background: #cce5ff; color: #004085; }
-			.ttbm-wishlist-empty-state { text-align: center; padding: 60px 20px; color: #888; }
-			.ttbm-wishlist-empty-state .dashicons { font-size: 48px; width: 48px; height: 48px; color: #ddd; }
-			.ttbm-wishlist-empty-state h3 { margin: 16px 0 4px; font-size: 18px; color: #555; }
-			.ttbm-wishlist-empty-state p { font-size: 14px; color: #888; }
-			@media (max-width: 782px) {
-				.ttbm-filter-row { flex-direction: column; align-items: stretch; }
-				.ttbm-filter-input, .ttbm-filter-select { width: 100%; min-width: 0; }
-			}
-			</style>
 			<?php
 		}
 	}

--- a/admin/TTBM_Admin_Wishlist.php
+++ b/admin/TTBM_Admin_Wishlist.php
@@ -52,13 +52,6 @@ if ( ! class_exists( 'TTBM_Admin_Wishlist' ) ) {
 		private function get_wishlist_data( $search = '', $tour_id = 0, $paged = 1, $per_page = 20 ) {
 			global $wpdb;
 
-			// Only get non-admin users who have a wishlist
-			$admin_ids = get_users( array(
-				'capability' => array( 'manage_options' ),
-				'fields'     => 'ID',
-			) );
-			$exclude = array_map( 'intval', (array) $admin_ids );
-
 			$user_ids = $wpdb->get_col( $wpdb->prepare(
 				"SELECT user_id FROM {$wpdb->usermeta} WHERE meta_key = %s",
 				'ttbm_wishlist'
@@ -68,10 +61,6 @@ if ( ! class_exists( 'TTBM_Admin_Wishlist' ) ) {
 
 			if ( ! empty( $user_ids ) ) {
 				foreach ( $user_ids as $uid ) {
-					// Skip admin users — only show real customers
-					if ( in_array( intval( $uid ), $exclude, true ) ) {
-						continue;
-					}
 					$list = get_user_meta( $uid, 'ttbm_wishlist', true );
 					if ( ! is_array( $list ) || empty( $list ) ) {
 						continue;

--- a/admin/ttbm-wishlist-admin.css
+++ b/admin/ttbm-wishlist-admin.css
@@ -1,0 +1,103 @@
+.ttbm-wishlist-admin-wrap {
+    margin-top: 16px;
+}
+.ttbm-wishlist-header {
+    margin-bottom: 12px;
+}
+.ttbm-wishlist-header h2 {
+    font-size: 18px;
+    font-weight: 600;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+.ttbm-wishlist-header h2 i {
+    color: #e84c6a;
+}
+.ttbm-wishlist-count {
+    font-size: 13px;
+    font-weight: 400;
+    color: #888;
+}
+.ttbm-wishlist-filters {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 16px;
+    flex-wrap: wrap;
+    background: #fff;
+    border: 1px solid #ccd0d4;
+    border-radius: 4px;
+    padding: 10px 14px;
+}
+.ttbm-wishlist-filter-input {
+    min-width: 220px;
+}
+.ttbm-wishlist-filter-select {
+    min-width: 180px;
+}
+.ttbm-wishlist-table td {
+    vertical-align: middle;
+}
+.ttbm-wishlist-table td a {
+    text-decoration: none;
+}
+.ttbm-wishlist-table td a:hover {
+    color: #6c47ff;
+}
+.ttbm-subtle {
+    color: #999;
+}
+.ttbm-status {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 3px;
+    font-size: 12px;
+    font-weight: 500;
+}
+.ttbm-status-publish {
+    background: #d4edda;
+    color: #155724;
+}
+.ttbm-status-draft {
+    background: #fff3cd;
+    color: #856404;
+}
+.ttbm-status-pending {
+    background: #cce5ff;
+    color: #004085;
+}
+.ttbm-wishlist-empty-state {
+    text-align: center;
+    padding: 60px 20px;
+    color: #888;
+}
+.ttbm-wishlist-empty-state h3 {
+    margin: 16px 0 4px;
+    font-size: 18px;
+    color: #555;
+}
+.ttbm-wishlist-empty-state p {
+    font-size: 14px;
+    color: #888;
+}
+.ttbm-wishlist-pagination {
+    margin-top: 12px;
+}
+.ttbm-wishlist-pagination .tablenav-pages {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+@media (max-width: 782px) {
+    .ttbm-wishlist-filters {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .ttbm-wishlist-filter-input,
+    .ttbm-wishlist-filter-select {
+        width: 100%;
+        min-width: 0;
+    }
+}

--- a/assets/admin/ttbm_hotel_booking.js
+++ b/assets/admin/ttbm_hotel_booking.js
@@ -1530,6 +1530,40 @@
         }, 2000);
     });
 
+    // ─── Wishlist Tab Filtering & Pagination ─────────────────
+    $(document).on('click', '#ttbm-wishlist-filter-btn', function() {
+        ttbm_wishlist_load(1);
+    });
+    $(document).on('keypress', '#ttbm-wishlist-search', function(e) {
+        if (e.which === 13) { e.preventDefault(); ttbm_wishlist_load(1); }
+    });
+    $(document).on('click', '#ttbm-wishlist-reset-btn', function() {
+        $('#ttbm-wishlist-search').val('');
+        $('#ttbm-wishlist-tour-filter').val('0');
+        ttbm_wishlist_load(1);
+    });
+    $(document).on('click', '#ttbm-wishlist-pagination .button[data-page]', function() {
+        ttbm_wishlist_load($(this).data('page'));
+    });
+
+    function ttbm_wishlist_load(page) {
+        var search  = $('#ttbm-wishlist-search').val();
+        var tourId  = $('#ttbm-wishlist-tour-filter').val();
+        var $wrap   = $('#ttbm_trvel_lists_wishlist .ttbm-wishlist-admin-wrap');
+        $wrap.css('opacity', 0.5);
+        $.post(ttbm_admin_ajax.ajax_url, {
+            action: 'ttbm_wishlist_admin_data',
+            nonce: ttbm_admin_ajax.nonce,
+            search: search,
+            tour_id: tourId,
+            paged: page
+        }, function(res) {
+            if (res.success) {
+                $wrap.replaceWith(res.data.html);
+            }
+        });
+    }
+
 })(jQuery);
 
 

--- a/assets/frontend/ttbm_registration.css
+++ b/assets/frontend/ttbm_registration.css
@@ -5031,6 +5031,13 @@ div.filter_item.ttbm-grid-card:hover,
 .ttbm-gc-wishlist.active .mi {
 	color: #e84c6a;
 }
+.ttbm-gc-wishlist.active .mi-wishlist-heart {
+	color: #fff;
+}
+.ttbm-gc-wishlist.active {
+	background: #e84c6a;
+	border-color: #e84c6a;
+}
 
 /* --- Duration badge on image ---------------------------------------------- */
 div.ttbm-tour-list-shortcode .ttbm-gc-duration-badge {

--- a/assets/frontend/ttbm_script.js
+++ b/assets/frontend/ttbm_script.js
@@ -284,4 +284,75 @@
     }
 
 
+	// ═══ Wishlist Toggle ═══════════════════════════════════════════
+	$(document).on('click', '.ttbm-gc-wishlist', function(e) {
+		e.preventDefault();
+		e.stopPropagation();
+		e.stopImmediatePropagation();
+
+		var btn = $(this);
+		var tourId = btn.data('tour-id');
+
+		if (!tourId) return;
+
+		$.ajax({
+			type: 'POST',
+			url: ttbm_ajax.ajax_url,
+			data: {
+				action: 'ttbm_wishlist_toggle',
+				nonce: ttbm_ajax.nonce,
+				tour_id: tourId
+			},
+			success: function(response) {
+				if (response.success) {
+					var icon = btn.find('.mi');
+					if (response.data.in_wishlist) {
+						btn.addClass('active');
+						icon.removeClass('mi-heart').addClass('mi-wishlist-heart');
+					} else {
+						btn.removeClass('active');
+						icon.removeClass('mi-wishlist-heart').addClass('mi-heart');
+					}
+				} else if (response.data && response.data.need_login) {
+					// Show login modal
+					$('#ttbm-wishlist-login-modal').addClass('ttbm-modal-active');
+				}
+			},
+			error: function() {
+				// Fallback: show modal for any AJAX failure when not logged in
+				if (!ttbm_ajax_is_logged_in) {
+					$('#ttbm-wishlist-login-modal').addClass('ttbm-modal-active');
+				}
+			}
+		});
+	});
+
+	// Close modal
+	$(document).on('click', '.ttbm-modal-close, .ttbm-modal-overlay', function() {
+		$(this).closest('.ttbm-modal-wrap').removeClass('ttbm-modal-active');
+	});
+
+	// ═══ Wishlist Remove (My Account page) ══════════════════════════
+	$(document).on('click', '.ttbm-wishlist-remove', function(e) {
+		e.preventDefault();
+		var btn = $(this);
+		var tourId = btn.data('tour-id');
+		if (!tourId) return;
+
+		$.ajax({
+			type: 'POST',
+			url: ttbm_ajax.ajax_url,
+			data: {
+				action: 'ttbm_wishlist_toggle',
+				nonce: ttbm_ajax.nonce,
+				tour_id: tourId
+			},
+			success: function(response) {
+				if (response.success && !response.data.in_wishlist) {
+					btn.closest('.ttbm-wishlist-item').fadeOut(300, function() { $(this).remove(); });
+				}
+			}
+		});
+	});
+
 }(jQuery));

--- a/assets/frontend/ttbm_script.js
+++ b/assets/frontend/ttbm_script.js
@@ -355,4 +355,24 @@
 		});
 	});
 
+	// ═══ Wishlist View Toggle (Grid / List) ══════════════════════════
+	$(document).on('click', '.ttbm-wishlist-view-btn', function(e) {
+		e.preventDefault();
+		var btn = $(this);
+		var view = btn.data('view');
+		var container = btn.closest('.ttbm-myaccount-wishlist');
+		var grid = container.find('.ttbm-wishlist-grid');
+
+		// Toggle active state on buttons
+		container.find('.ttbm-wishlist-view-btn').removeClass('ttbm-wishlist-view-active').attr('aria-pressed', 'false');
+		btn.addClass('ttbm-wishlist-view-active').attr('aria-pressed', 'true');
+
+		// Switch view class on grid container
+		if (view === 'list') {
+			grid.removeClass('ttbm-wishlist-view-grid').addClass('ttbm-wishlist-view-list');
+		} else {
+			grid.removeClass('ttbm-wishlist-view-list').addClass('ttbm-wishlist-view-grid');
+		}
+	});
+
 }(jQuery));

--- a/assets/mp_style/ttbm_plugin_global.js
+++ b/assets/mp_style/ttbm_plugin_global.js
@@ -291,7 +291,8 @@ function ttbm_resize_bg_image_area(target, bg_url) {
             });
         }
     });
-    $(document).on('click', 'div.ttbm_style [data-href]', function () {
+    $(document).on('click', 'div.ttbm_style [data-href]', function (e) {
+        if ($(e.target).closest('.ttbm-gc-wishlist').length) return;
         let href = $(this).data('href');
         if (href) {
             window.location.href = href;

--- a/inc/TTBM_Dependencies.php
+++ b/inc/TTBM_Dependencies.php
@@ -44,8 +44,9 @@
 					require_once TTBM_PLUGIN_DIR . '/inc/TTBM_Hotel_Details_Layout.php';
 					require_once TTBM_PLUGIN_DIR . '/inc/TTBM_Booking.php';
 					require_once TTBM_PLUGIN_DIR . '/inc/TTBM_Hotel_Booking.php';
-require_once TTBM_PLUGIN_DIR . '/inc/TTBM_Woocommerce.php';
+					require_once TTBM_PLUGIN_DIR . '/inc/TTBM_Woocommerce.php';
 					require_once TTBM_PLUGIN_DIR . '/inc/TTBM_Wishlist.php';
+					require_once TTBM_PLUGIN_DIR . '/admin/TTBM_Admin_Wishlist.php';
 				}
 			}
 			public function appsero_init_tracker_ttbm() {

--- a/inc/TTBM_Dependencies.php
+++ b/inc/TTBM_Dependencies.php
@@ -45,6 +45,7 @@
 					require_once TTBM_PLUGIN_DIR . '/inc/TTBM_Booking.php';
 					require_once TTBM_PLUGIN_DIR . '/inc/TTBM_Hotel_Booking.php';
 require_once TTBM_PLUGIN_DIR . '/inc/TTBM_Woocommerce.php';
+					require_once TTBM_PLUGIN_DIR . '/inc/TTBM_Wishlist.php';
 				}
 			}
 			public function appsero_init_tracker_ttbm() {
@@ -236,6 +237,7 @@ require_once TTBM_PLUGIN_DIR . '/inc/TTBM_Woocommerce.php';
                     let ttbm_empty_image_url = "<?php echo esc_attr(TTBM_PLUGIN_URL . '/assets/images/no_image.png'); ?>";
                     let ttbm_date_format = "<?php echo esc_attr(TTBM_Global_Function::get_settings('ttbm_global_settings', 'date_format', 'D d M , yy')); ?>";
                     let ttbm_date_format_without_year = "<?php echo esc_attr(TTBM_Global_Function::get_settings('ttbm_global_settings', 'date_format_without_year', 'D d M')); ?>";
+                    let ttbm_ajax_is_logged_in = <?php echo is_user_logged_in() ? 'true' : 'false'; ?>;
                 </script>
 				<?php
 				if (TTBM_Global_Function::check_woocommerce() == 1) {

--- a/inc/TTBM_Wishlist.php
+++ b/inc/TTBM_Wishlist.php
@@ -180,12 +180,24 @@ if ( ! class_exists( 'TTBM_Wishlist' ) ) {
 
 			?>
 			<div class="ttbm-myaccount-wishlist">
-				<h2><?php esc_html_e( 'My Wishlist', 'tour-booking-manager' ); ?></h2>
+				<div class="ttbm-wishlist-header">
+					<h2><?php esc_html_e( 'My Wishlist', 'tour-booking-manager' ); ?></h2>
+					<?php if ( ! empty( $tour_ids ) ) : ?>
+					<div class="ttbm-wishlist-view-toggle">
+						<button type="button" class="ttbm-wishlist-view-btn ttbm-wishlist-view-active" data-view="grid" aria-pressed="true" title="<?php esc_attr_e( 'Grid view', 'tour-booking-manager' ); ?>">
+							<span class="mi mi-grid"></span>
+						</button>
+						<button type="button" class="ttbm-wishlist-view-btn" data-view="list" aria-pressed="false" title="<?php esc_attr_e( 'List view', 'tour-booking-manager' ); ?>">
+							<span class="mi mi-list"></span>
+						</button>
+					</div>
+					<?php endif; ?>
+				</div>
 
 				<?php if ( empty( $tour_ids ) ) : ?>
 					<p class="ttbm-wishlist-empty"><?php esc_html_e( 'Your wishlist is empty.', 'tour-booking-manager' ); ?></p>
 				<?php else : ?>
-					<div class="ttbm-wishlist-grid">
+					<div class="ttbm-wishlist-grid ttbm-wishlist-view-grid">
 						<?php foreach ( $tour_ids as $tour_id ) :
 							$tour = get_post( $tour_id );
 							if ( ! $tour || $tour->post_status !== 'publish' ) {
@@ -225,8 +237,8 @@ if ( ! class_exists( 'TTBM_Wishlist' ) ) {
 									<a href="<?php echo esc_url( get_permalink( $tour_id ) ); ?>">
 										<img src="<?php echo esc_url( $thumbnail ); ?>" alt="<?php echo esc_attr( get_the_title( $tour_id ) ); ?>" />
 									</a>
-									<button type="button" class="ttbm-wishlist-remove" data-tour-id="<?php echo esc_attr( $tour_id ); ?>" title="<?php esc_attr_e( 'Remove from wishlist', 'tour-booking-manager' ); ?>">
-										<span class="mi mi-heart"></span>
+									<button type="button" class="ttbm-wishlist-remove ttbm-wishlist-in-list" data-tour-id="<?php echo esc_attr( $tour_id ); ?>" title="<?php esc_attr_e( 'Remove from wishlist', 'tour-booking-manager' ); ?>">
+										<span class="mi mi-wishlist-heart"></span>
 									</button>
 								</div>
 								<div class="ttbm-wishlist-item-info">
@@ -296,27 +308,77 @@ if ( ! class_exists( 'TTBM_Wishlist' ) ) {
 			.ttbm-modal-btn{display:inline-block;background:#6c47ff;color:#fff;padding:10px 28px;border-radius:8px;text-decoration:none;font-size:14px;font-weight:600;transition:background .2s;}
 			.ttbm-modal-btn:hover{background:#5a3be0;color:#fff;}
 
-			/* ── My Account Wishlist ──────────────────────────────── */
+			/* ── Wishlist Header & View Toggle ──────────────────── */
+			.ttbm-wishlist-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:4px;flex-wrap:wrap;gap:10px;}
+			.ttbm-wishlist-header h2{margin:0;}
+			.ttbm-wishlist-view-toggle{display:flex;gap:4px;background:#f1f1f5;border-radius:8px;padding:3px;}
+			.ttbm-wishlist-view-btn{display:flex;align-items:center;justify-content:center;width:34px;height:34px;border:none;border-radius:6px;background:transparent;color:#9ca3af;cursor:pointer;transition:background .18s ease,color .18s ease;font-size:16px;padding:0;line-height:1;}
+			.ttbm-wishlist-view-btn .mi{font-size:16px;color:inherit;}
+			.ttbm-wishlist-view-btn:hover{background:#e8e8ef;color:#374151;}
+			.ttbm-wishlist-view-btn.ttbm-wishlist-view-active,
+			.ttbm-wishlist-view-btn[aria-pressed="true"]{background:#6c47ff;color:#fff;}
+			.ttbm-wishlist-view-btn.ttbm-wishlist-view-active .mi,
+			.ttbm-wishlist-view-btn[aria-pressed="true"] .mi{color:#fff;}
+
+			/* ── My Account Wishlist Grid ────────────────────────── */
 			.ttbm-myaccount-wishlist{margin-top:10px;}
 			.ttbm-wishlist-empty{color:#888;font-size:15px;}
-			.ttbm-wishlist-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:20px;margin-top:16px;}
-			.ttbm-wishlist-item{background:#fff;border:1px solid #eee;border-radius:12px;overflow:hidden;transition:box-shadow .2s;}
-			.ttbm-wishlist-item:hover{box-shadow:0 4px 16px rgba(0,0,0,.1);}
-			.ttbm-wishlist-item-thumb{position:relative;}
-			.ttbm-wishlist-item-thumb img{width:100%;height:180px;object-fit:cover;display:block;}
-			.ttbm-wishlist-remove{position:absolute;top:10px;right:10px;background:rgba(255,255,255,.92);border:none;border-radius:50%;width:34px;height:34px;cursor:pointer;display:flex;align-items:center;justify-content:center;box-shadow:0 2px 6px rgba(0,0,0,.15);transition:background .2s,transform .2s;padding:0;}
-			.ttbm-wishlist-remove .mi{font-size:16px;color:#e84c6a;}
-			.ttbm-wishlist-remove:hover{background:#fff;transform:scale(1.12);}
-			.ttbm-wishlist-item-info{padding:14px 16px;}
-			.ttbm-wishlist-item-info h3{margin:0 0 10px;font-size:16px;font-weight:600;line-height:1.4;}
-			.ttbm-wishlist-item-info h3 a{color:#222;text-decoration:none;}
-			.ttbm-wishlist-item-info h3 a:hover{color:#6c47ff;}
-			.ttbm-wishlist-meta{display:flex;align-items:center;gap:4px;font-size:13px;color:#666;margin-bottom:6px;}
-			.ttbm-wishlist-meta .mi{font-size:13px;color:#999;}
-			.ttbm-wishlist-price{font-size:16px;font-weight:700;color:#6c47ff;margin-top:4px;margin-bottom:10px;}
-			.ttbm-wishlist-price .woocommerce-Price-amount{font-size:16px;}
-			.ttbm-wishlist-explore-btn{display:inline-block;background:#6c47ff;color:#fff !important;padding:8px 20px;border-radius:8px;text-decoration:none;font-size:13px;font-weight:600;transition:background .2s;}
-			.ttbm-wishlist-explore-btn:hover{background:#5a3be0;color:#fff !important;}
+
+			/* ── GRID VIEW (default) ─────────────────────────────── */
+			.ttbm-wishlist-grid.ttbm-wishlist-view-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:20px;margin-top:16px;}
+			.ttbm-wishlist-view-grid .ttbm-wishlist-item{background:#fff;border:1px solid #eee;border-radius:12px;overflow:hidden;transition:box-shadow .2s;}
+			.ttbm-wishlist-view-grid .ttbm-wishlist-item:hover{box-shadow:0 4px 16px rgba(0,0,0,.1);}
+			.ttbm-wishlist-view-grid .ttbm-wishlist-item-thumb{position:relative;}
+			.ttbm-wishlist-view-grid .ttbm-wishlist-item-thumb img{width:100%;height:180px;object-fit:cover;display:block;}
+			.ttbm-wishlist-view-grid .ttbm-wishlist-remove{position:absolute;top:10px;right:10px;background:#e84c6a;border:none;border-radius:50%;width:34px;height:34px;cursor:pointer;display:flex;align-items:center;justify-content:center;box-shadow:0 2px 8px rgba(232,76,106,.35);transition:background .2s,transform .2s;padding:0;}
+			.ttbm-wishlist-view-grid .ttbm-wishlist-remove .mi{font-size:16px;color:#fff;}
+			.ttbm-wishlist-view-grid .ttbm-wishlist-remove:hover{background:#d63d5e;transform:scale(1.15);}.ttbm-wishlist-view-grid .ttbm-wishlist-remove:hover .mi{color:#fff;}
+			.ttbm-wishlist-view-grid .ttbm-wishlist-item-info{padding:14px 16px;}
+			.ttbm-wishlist-view-grid .ttbm-wishlist-item-info h3{margin:0 0 10px;font-size:16px;font-weight:600;line-height:1.4;}
+			.ttbm-wishlist-view-grid .ttbm-wishlist-item-info h3 a{color:#222;text-decoration:none;}
+			.ttbm-wishlist-view-grid .ttbm-wishlist-item-info h3 a:hover{color:#6c47ff;}
+			.ttbm-wishlist-view-grid .ttbm-wishlist-meta{display:flex;align-items:center;gap:4px;font-size:13px;color:#666;margin-bottom:6px;}
+			.ttbm-wishlist-view-grid .ttbm-wishlist-meta .mi{font-size:13px;color:#999;}
+			.ttbm-wishlist-view-grid .ttbm-wishlist-price{font-size:16px;font-weight:700;color:#6c47ff;margin-top:4px;margin-bottom:10px;}
+			.ttbm-wishlist-view-grid .ttbm-wishlist-price .woocommerce-Price-amount{font-size:16px;}
+			.ttbm-wishlist-view-grid .ttbm-wishlist-explore-btn{display:inline-block;background:#6c47ff;color:#fff !important;padding:8px 20px;border-radius:8px;text-decoration:none;font-size:13px;font-weight:600;transition:background .2s;}
+			.ttbm-wishlist-view-grid .ttbm-wishlist-explore-btn:hover{background:#5a3be0;color:#fff !important;}
+
+			/* ── LIST VIEW ────────────────────────────────────────── */
+			.ttbm-wishlist-grid.ttbm-wishlist-view-list{display:flex;flex-direction:column;gap:16px;margin-top:16px;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-item{display:flex;flex-direction:row;align-items:stretch;background:#fff;border:1px solid #eee;border-radius:14px;overflow:hidden;transition:box-shadow .2s;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-item:hover{box-shadow:0 4px 16px rgba(0,0,0,.1);}
+			.ttbm-wishlist-view-list .ttbm-wishlist-item-thumb{position:relative;width:300px;min-width:300px;max-width:300px;flex-shrink:0;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-item-thumb img{width:100%;height:100%;min-height:100%;object-fit:cover;display:block;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-remove{position:absolute;top:10px;right:10px;background:#e84c6a;border:none;border-radius:50%;width:34px;height:34px;cursor:pointer;display:flex;align-items:center;justify-content:center;box-shadow:0 2px 8px rgba(232,76,106,.35);transition:background .2s,transform .2s;padding:0;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-remove .mi{font-size:16px;color:#fff;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-remove:hover{background:#d63d5e;transform:scale(1.15);}.ttbm-wishlist-view-list .ttbm-wishlist-remove:hover .mi{color:#fff;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-item-info{flex:1;display:flex;flex-direction:column;padding:20px 24px;min-width:0;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-item-info h3{margin:0 0 10px;font-size:20px;font-weight:600;line-height:1.3;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-item-info h3 a{color:#222;text-decoration:none;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-item-info h3 a:hover{color:#6c47ff;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-meta{display:flex;align-items:center;gap:4px;font-size:13px;color:#666;margin-bottom:6px;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-meta .mi{font-size:13px;color:#999;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-price{font-size:22px;font-weight:700;color:#6c47ff;margin-top:auto;margin-bottom:12px;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-price .woocommerce-Price-amount{font-size:22px;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-explore-btn{display:inline-block;background:#6c47ff;color:#fff !important;padding:10px 24px;border-radius:8px;text-decoration:none;font-size:14px;font-weight:600;transition:background .2s;align-self:flex-start;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-explore-btn:hover{background:#5a3be0;color:#fff !important;}
+
+			/* ── List View Responsive ─────────────────────────────── */
+			@media (max-width:767px) {
+			.ttbm-wishlist-view-list .ttbm-wishlist-item{flex-direction:column !important;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-item-thumb{width:100%;max-width:100%;min-width:100%;height:220px;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-item-thumb img{height:220px;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-item-info{padding:16px;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-item-info h3{font-size:18px;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-explore-btn{width:100%;text-align:center;}
+			}
+			@media (max-width:480px) {
+			.ttbm-wishlist-view-list .ttbm-wishlist-item-thumb{height:200px;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-item-thumb img{height:200px;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-item-info{padding:14px;}
+			.ttbm-wishlist-view-list .ttbm-wishlist-item-info h3{font-size:16px;}
+			}
 			</style>
 			<?php
 		}

--- a/inc/TTBM_Wishlist.php
+++ b/inc/TTBM_Wishlist.php
@@ -1,0 +1,325 @@
+<?php
+/*
+* Wishlist functionality for Tour Booking Manager
+* Handles: AJAX add/remove, user meta storage, My Account endpoint
+*/
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+if ( ! class_exists( 'TTBM_Wishlist' ) ) {
+	class TTBM_Wishlist {
+
+		private static $meta_key = 'ttbm_wishlist';
+
+		public function __construct() {
+			// AJAX handlers
+			add_action( 'wp_ajax_ttbm_wishlist_toggle', array( $this, 'ajax_toggle' ) );
+			add_action( 'wp_ajax_nopriv_ttbm_wishlist_toggle', array( $this, 'ajax_not_logged_in' ) );
+
+			// My Account endpoint
+			add_action( 'init', array( $this, 'add_endpoint' ) );
+			add_filter( 'woocommerce_get_query_vars', array( $this, 'add_query_var' ) );
+			add_filter( 'woocommerce_account_menu_items', array( $this, 'add_menu_item' ) );
+			add_action( 'woocommerce_account_ttbm-wishlist_endpoint', array( $this, 'endpoint_content' ) );
+
+			// Login modal + CSS in footer
+			add_action( 'wp_footer', array( $this, 'login_modal' ) );
+			add_action( 'wp_footer', array( $this, 'modal_css' ) );
+		}
+
+		// ─── User Meta Storage ──────────────────────────────────────
+
+		/**
+		 * Get wishlist tour IDs for a user.
+		 */
+		public static function get_wishlist( $user_id = 0 ) {
+			if ( ! $user_id ) {
+				$user_id = get_current_user_id();
+			}
+			if ( ! $user_id ) {
+				return array();
+			}
+			$list = get_user_meta( $user_id, self::$meta_key, true );
+			return is_array( $list ) ? $list : array();
+		}
+
+		/**
+		 * Add a tour to the user's wishlist. Returns true on success.
+		 */
+		public static function add( $tour_id, $user_id = 0 ) {
+			if ( ! $user_id ) {
+				$user_id = get_current_user_id();
+			}
+			if ( ! $user_id ) {
+				return false;
+			}
+			$list   = self::get_wishlist( $user_id );
+			$tour_id = (int) $tour_id;
+			if ( ! in_array( $tour_id, $list, true ) ) {
+				$list[] = $tour_id;
+				update_user_meta( $user_id, self::$meta_key, $list );
+			}
+			return true;
+		}
+
+		/**
+		 * Remove a tour from the user's wishlist. Returns true on success.
+		 */
+		public static function remove( $tour_id, $user_id = 0 ) {
+			if ( ! $user_id ) {
+				$user_id = get_current_user_id();
+			}
+			if ( ! $user_id ) {
+				return false;
+			}
+			$list   = self::get_wishlist( $user_id );
+			$tour_id = (int) $tour_id;
+			$list    = array_values( array_diff( $list, array( $tour_id ) ) );
+			update_user_meta( $user_id, self::$meta_key, $list );
+			return true;
+		}
+
+		/**
+		 * Check if a tour is in the user's wishlist.
+		 */
+		public static function is_in_wishlist( $tour_id, $user_id = 0 ) {
+			$list = self::get_wishlist( $user_id );
+			return in_array( (int) $tour_id, $list, true );
+		}
+
+		// ─── AJAX Handlers ──────────────────────────────────────────
+
+		/**
+		 * AJAX: Toggle wishlist for logged-in users.
+		 */
+		public function ajax_toggle() {
+			check_ajax_referer( 'ttbm_frontend_nonce', 'nonce' );
+
+			if ( ! is_user_logged_in() ) {
+				wp_send_json_error( array(
+					'message'    => esc_html__( 'Please log in to add to wishlist.', 'tour-booking-manager' ),
+					'need_login' => true,
+				) );
+			}
+
+			$tour_id = isset( $_POST['tour_id'] ) ? absint( $_POST['tour_id'] ) : 0;
+			if ( ! $tour_id || get_post_type( $tour_id ) !== 'ttbm_tour' ) {
+				wp_send_json_error( array( 'message' => esc_html__( 'Invalid tour.', 'tour-booking-manager' ) ) );
+			}
+
+			$user_id = get_current_user_id();
+
+			if ( self::is_in_wishlist( $tour_id, $user_id ) ) {
+				self::remove( $tour_id, $user_id );
+				$in_wishlist = false;
+				$action_text = esc_html__( 'Removed from wishlist', 'tour-booking-manager' );
+			} else {
+				self::add( $tour_id, $user_id );
+				$in_wishlist = true;
+				$action_text = esc_html__( 'Added to wishlist', 'tour-booking-manager' );
+			}
+
+			wp_send_json_success( array(
+				'in_wishlist' => $in_wishlist,
+				'message'     => $action_text,
+			) );
+		}
+
+		/**
+		 * AJAX: Not-logged-in response — tells JS to show login modal.
+		 */
+		public function ajax_not_logged_in() {
+			wp_send_json_error( array(
+				'message'    => esc_html__( 'Please log in to add to wishlist.', 'tour-booking-manager' ),
+				'need_login' => true,
+			) );
+		}
+
+		// ─── My Account Endpoint ─────────────────────────────────────
+
+		/**
+		 * Register the /my-account/ttbm-wishlist/ rewrite endpoint.
+		 */
+		public function add_endpoint() {
+			add_rewrite_endpoint( 'ttbm-wishlist', EP_PAGES );
+		}
+
+		/**
+		 * Tell WooCommerce about our custom query var.
+		 */
+		public function add_query_var( $vars ) {
+			$vars['ttbm-wishlist'] = 'ttbm-wishlist';
+			return $vars;
+		}
+
+		/**
+		 * Add "Wishlist" menu item to My Account navigation.
+		 */
+		public function add_menu_item( $items ) {
+			$logout = isset( $items['customer-logout'] ) ? $items['customer-logout'] : null;
+			unset( $items['customer-logout'] );
+
+			$items['ttbm-wishlist'] = esc_html__( 'Wishlist', 'tour-booking-manager' );
+
+			if ( $logout ) {
+				$items['customer-logout'] = $logout;
+			}
+			return $items;
+		}
+
+		/**
+		 * Render the Wishlist tab content on My Account page.
+		 */
+		public function endpoint_content() {
+			if ( ! is_user_logged_in() ) {
+				return;
+			}
+
+			$user_id    = get_current_user_id();
+			$tour_ids   = self::get_wishlist( $user_id );
+
+			?>
+			<div class="ttbm-myaccount-wishlist">
+				<h2><?php esc_html_e( 'My Wishlist', 'tour-booking-manager' ); ?></h2>
+
+				<?php if ( empty( $tour_ids ) ) : ?>
+					<p class="ttbm-wishlist-empty"><?php esc_html_e( 'Your wishlist is empty.', 'tour-booking-manager' ); ?></p>
+				<?php else : ?>
+					<div class="ttbm-wishlist-grid">
+						<?php foreach ( $tour_ids as $tour_id ) :
+							$tour = get_post( $tour_id );
+							if ( ! $tour || $tour->post_status !== 'publish' ) {
+								continue;
+							}
+							$ttbm_post_id = $tour_id;
+							$thumbnail    = get_the_post_thumbnail_url( $tour_id, 'medium' );
+							if ( ! $thumbnail ) {
+								$thumbnail = TTBM_PLUGIN_URL . '/assets/images/no_image.png';
+							}
+							$location      = TTBM_Global_Function::get_post_info( $tour_id, 'ttbm_location_name' );
+							$duration       = TTBM_Function::get_duration( $tour_id );
+							$night          = TTBM_Global_Function::get_post_info( $tour_id, 'ttbm_travel_duration_night' );
+							$duration_type  = TTBM_Global_Function::get_post_info( $tour_id, 'ttbm_travel_duration_type', 'day' );
+							$start_price    = TTBM_Function::get_tour_start_price( $tour_id );
+							$regular_price  = TTBM_Function::check_discount_price_exit( $tour_id );
+							$show_price     = TTBM_Global_Function::get_post_info( $tour_id, 'ttbm_display_price_start', 'on' ) !== 'off';
+
+							$duration_label = '';
+							if ( $duration ) {
+								$duration_label .= esc_html( $duration ) . ' ';
+								if ( $duration_type === 'day' ) {
+									$duration_label .= $duration > 1 ? esc_html__( 'DAYS', 'tour-booking-manager' ) : esc_html__( 'DAY', 'tour-booking-manager' );
+								} elseif ( $duration_type === 'min' ) {
+									$duration_label .= $duration > 1 ? esc_html__( 'MINUTES', 'tour-booking-manager' ) : esc_html__( 'MINUTE', 'tour-booking-manager' );
+								} else {
+									$duration_label .= $duration > 1 ? esc_html__( 'HOURS', 'tour-booking-manager' ) : esc_html__( 'HOUR', 'tour-booking-manager' );
+								}
+							}
+							if ( $night ) {
+								$duration_label .= ' / ' . esc_html( $night ) . ' ';
+								$duration_label .= $night > 1 ? esc_html__( 'NIGHTS', 'tour-booking-manager' ) : esc_html__( 'NIGHT', 'tour-booking-manager' );
+							}
+							?>
+							<div class="ttbm-wishlist-item" data-tour-id="<?php echo esc_attr( $tour_id ); ?>">
+								<div class="ttbm-wishlist-item-thumb">
+									<a href="<?php echo esc_url( get_permalink( $tour_id ) ); ?>">
+										<img src="<?php echo esc_url( $thumbnail ); ?>" alt="<?php echo esc_attr( get_the_title( $tour_id ) ); ?>" />
+									</a>
+									<button type="button" class="ttbm-wishlist-remove" data-tour-id="<?php echo esc_attr( $tour_id ); ?>" title="<?php esc_attr_e( 'Remove from wishlist', 'tour-booking-manager' ); ?>">
+										<span class="mi mi-heart"></span>
+									</button>
+								</div>
+								<div class="ttbm-wishlist-item-info">
+									<h3><a href="<?php echo esc_url( get_permalink( $tour_id ) ); ?>"><?php echo esc_html( get_the_title( $tour_id ) ); ?></a></h3>
+									<?php if ( $location ) : ?>
+										<div class="ttbm-wishlist-meta"><span class="mi mi-map-pin"></span> <?php echo esc_html( $location ); ?></div>
+									<?php endif; ?>
+									<?php if ( $duration_label ) : ?>
+										<div class="ttbm-wishlist-meta"><span class="mi mi-clock"></span> <?php echo esc_html( $duration_label ); ?></div>
+									<?php endif; ?>
+									<?php if ( $start_price && $show_price ) : ?>
+										<div class="ttbm-wishlist-price"><?php echo wc_price( $start_price ); ?></div>
+									<?php endif; ?>
+									<a href="<?php echo esc_url( get_permalink( $tour_id ) ); ?>" class="ttbm-wishlist-explore-btn"><?php esc_html_e( 'Explore', 'tour-booking-manager' ); ?></a>
+								</div>
+							</div>
+						<?php endforeach; ?>
+					</div>
+				<?php endif; ?>
+			</div>
+			<?php
+		}
+
+		// ─── Login Modal & Footer Assets ──────────────────────────────
+
+		/**
+		 * Output login modal HTML in footer.
+		 */
+		public function login_modal() {
+			if ( is_user_logged_in() ) {
+				return;
+			}
+			$login_url = wp_login_url( get_permalink() );
+			?>
+			<div class="ttbm-modal-wrap" id="ttbm-wishlist-login-modal">
+				<div class="ttbm-modal-overlay"></div>
+				<div class="ttbm-modal-box">
+					<button type="button" class="ttbm-modal-close">×</button>
+					<div class="ttbm-modal-icon">
+						<span class="mi mi-heart"></span>
+					</div>
+					<h3 class="ttbm-modal-title"><?php esc_html_e( 'Login Required', 'tour-booking-manager' ); ?></h3>
+					<p class="ttbm-modal-text"><?php esc_html_e( 'Please log in to add tours to your wishlist.', 'tour-booking-manager' ); ?></p>
+					<a href="<?php echo esc_url( $login_url ); ?>" class="ttbm-modal-btn"><?php esc_html_e( 'Log In', 'tour-booking-manager' ); ?></a>
+				</div>
+			</div>
+			<?php
+		}
+
+		/**
+		 * Output wishlist CSS in footer.
+		 */
+		public function modal_css() {
+			?>
+			<style>
+			/* ── Wishlist Login Modal ─────────────────────────────── */
+			.ttbm-modal-wrap{display:none;position:fixed;top:0;left:0;right:0;bottom:0;z-index:999999;align-items:center;justify-content:center;}
+			.ttbm-modal-wrap.ttbm-modal-active{display:flex;}
+			.ttbm-modal-overlay{position:absolute;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,.55);}
+			.ttbm-modal-box{position:relative;background:#fff;border-radius:14px;padding:36px 30px 30px;max-width:380px;width:90%;text-align:center;box-shadow:0 16px 48px rgba(0,0,0,.18);z-index:1;}
+			.ttbm-modal-close{position:absolute;top:10px;right:14px;background:none;border:none;font-size:22px;color:#999;cursor:pointer;line-height:1;padding:4px;}
+			.ttbm-modal-close:hover{color:#333;}
+			.ttbm-modal-icon{margin-bottom:14px;}
+			.ttbm-modal-icon .mi{font-size:40px;color:#e84c6a;}
+			.ttbm-modal-title{font-size:20px;font-weight:600;margin:0 0 8px;color:#222;}
+			.ttbm-modal-text{font-size:14px;color:#666;margin:0 0 22px;}
+			.ttbm-modal-btn{display:inline-block;background:#6c47ff;color:#fff;padding:10px 28px;border-radius:8px;text-decoration:none;font-size:14px;font-weight:600;transition:background .2s;}
+			.ttbm-modal-btn:hover{background:#5a3be0;color:#fff;}
+
+			/* ── My Account Wishlist ──────────────────────────────── */
+			.ttbm-myaccount-wishlist{margin-top:10px;}
+			.ttbm-wishlist-empty{color:#888;font-size:15px;}
+			.ttbm-wishlist-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:20px;margin-top:16px;}
+			.ttbm-wishlist-item{background:#fff;border:1px solid #eee;border-radius:12px;overflow:hidden;transition:box-shadow .2s;}
+			.ttbm-wishlist-item:hover{box-shadow:0 4px 16px rgba(0,0,0,.1);}
+			.ttbm-wishlist-item-thumb{position:relative;}
+			.ttbm-wishlist-item-thumb img{width:100%;height:180px;object-fit:cover;display:block;}
+			.ttbm-wishlist-remove{position:absolute;top:10px;right:10px;background:rgba(255,255,255,.92);border:none;border-radius:50%;width:34px;height:34px;cursor:pointer;display:flex;align-items:center;justify-content:center;box-shadow:0 2px 6px rgba(0,0,0,.15);transition:background .2s,transform .2s;padding:0;}
+			.ttbm-wishlist-remove .mi{font-size:16px;color:#e84c6a;}
+			.ttbm-wishlist-remove:hover{background:#fff;transform:scale(1.12);}
+			.ttbm-wishlist-item-info{padding:14px 16px;}
+			.ttbm-wishlist-item-info h3{margin:0 0 10px;font-size:16px;font-weight:600;line-height:1.4;}
+			.ttbm-wishlist-item-info h3 a{color:#222;text-decoration:none;}
+			.ttbm-wishlist-item-info h3 a:hover{color:#6c47ff;}
+			.ttbm-wishlist-meta{display:flex;align-items:center;gap:4px;font-size:13px;color:#666;margin-bottom:6px;}
+			.ttbm-wishlist-meta .mi{font-size:13px;color:#999;}
+			.ttbm-wishlist-price{font-size:16px;font-weight:700;color:#6c47ff;margin-top:4px;margin-bottom:10px;}
+			.ttbm-wishlist-price .woocommerce-Price-amount{font-size:16px;}
+			.ttbm-wishlist-explore-btn{display:inline-block;background:#6c47ff;color:#fff !important;padding:8px 20px;border-radius:8px;text-decoration:none;font-size:13px;font-weight:600;transition:background .2s;}
+			.ttbm-wishlist-explore-btn:hover{background:#5a3be0;color:#fff !important;}
+			</style>
+			<?php
+		}
+	}
+	new TTBM_Wishlist();
+}

--- a/templates/list/grid_list.php
+++ b/templates/list/grid_list.php
@@ -19,8 +19,9 @@ $term_count   = 3;
 	<?php endif; ?>
 
 	<?php /* Wishlist button */ ?>
-	<button type="button" class="ttbm-gc-wishlist" aria-label="<?php esc_attr_e( 'Add to wishlist', 'tour-booking-manager' ); ?>" data-placeholder>
-		<span class="mi mi-heart"></span>
+	<?php $in_wishlist = is_user_logged_in() && TTBM_Wishlist::is_in_wishlist( $tour_id ); ?>
+	<button type="button" class="ttbm-gc-wishlist<?php echo $in_wishlist ? ' active' : ''; ?>" data-tour-id="<?php echo esc_attr( $tour_id ); ?>" aria-label="<?php esc_attr_e( 'Add to wishlist', 'tour-booking-manager' ); ?>">
+		<span class="mi <?php echo $in_wishlist ? 'mi-wishlist-heart' : 'mi-heart'; ?>"></span>
 	</button>
 
 	<?php /* Thumbnail */ ?>

--- a/templates/list/grid_list_style.php
+++ b/templates/list/grid_list_style.php
@@ -18,8 +18,9 @@ $term_count   = 3;
 	<?php endif; ?>
 
 	<?php /* Wishlist / favourite button */ ?>
-	<button type="button" class="ttbm-gc-wishlist" aria-label="<?php esc_attr_e( 'Add to wishlist', 'tour-booking-manager' ); ?>" data-placeholder>
-		<span class="mi mi-heart"></span>
+	<?php $in_wishlist = is_user_logged_in() && TTBM_Wishlist::is_in_wishlist( $tour_id ); ?>
+	<button type="button" class="ttbm-gc-wishlist<?php echo $in_wishlist ? ' active' : ''; ?>" data-tour-id="<?php echo esc_attr( $tour_id ); ?>" aria-label="<?php esc_attr_e( 'Add to wishlist', 'tour-booking-manager' ); ?>">
+		<span class="mi <?php echo $in_wishlist ? 'mi-wishlist-heart' : 'mi-heart'; ?>"></span>
 	</button>
 
 	<?php /* Tour thumbnail */ ?>


### PR DESCRIPTION
- New TTBM_Wishlist.php class handling: • AJAX toggle (add/remove) for logged-in users via user meta • Login required modal popup for guest users • WooCommerce My Account endpoint (/my-account/ttbm-wishlist/) • Wishlist tab in My Account navigation with tour cards showing: thumbnail, title, location, duration, price (wc_price), explore button, remove button

- Updated TTBM_Dependencies.php: • Load TTBM_Wishlist.php class • Expose ttbm_ajax_is_logged_in JS variable

- Updated wishlist buttons in templates: • grid_list_style.php: add data-tour-id, active class, mi-wishlist-heart icon when in wishlist • grid_list.php: same wishlist button updates

- Updated ttbm_script.js: • Click handler for .ttbm-gc-wishlist with AJAX toggle • Icon swap mi-heart <-> mi-wishlist-heart on toggle • stopImmediatePropagation to prevent data-href navigation • Login modal show on need_login response • Remove handler for My Account wishlist page (fade out animation)

- Updated ttbm_registration.css: • .ttbm-gc-wishlist.active: red background with white heart • .ttbm-gc-wishlist.active .mi-wishlist-heart: white icon

- Updated ttbm_plugin_global.js: • data-href click handler: skip navigation if click target is .ttbm-gc-wishlist

- Added modal CSS and HTML output via wp_footer hooks in TTBM_Wishlist.php