### PR TITLE
Fix tour list filtering and date tabs

### DIFF
--- a/assets/frontend/filter_pagination.js
+++ b/assets/frontend/filter_pagination.js
@@ -227,7 +227,7 @@
 		date_range_filter: 'data-date',
 	};
 	//************Filter*************//
-	$(document).on('change', '.ttbm_filter .formControl', function (e) {
+	$(document).on('change', '.ttbm_filter .formControl:not([type="checkbox"]):not([type="radio"]), .ttbm_filter input[type="hidden"]', function (e) {
 		e.preventDefault();
 		let parent = $(this).closest('.ttbm_filter_area');
 		list_filter(parent);

--- a/assets/frontend/ttbm_registration.css
+++ b/assets/frontend/ttbm_registration.css
@@ -5807,8 +5807,8 @@ div.filter_item .ttbm-gc-image-wrap~div.bg_image_area {
 
 /* Main list card */
 .all_filter_item .flexWrap.ttbm-list-mode .filter_item {
-	display: flex !important;
-	flex-direction: row !important;
+	display: flex;
+	flex-direction: row;
 	align-items: stretch;
 	width: 100% !important;
 	max-width: 100%;
@@ -5916,7 +5916,7 @@ div.filter_item .ttbm-gc-image-wrap~div.bg_image_area {
 @media (max-width: 991px) {
 
 	.all_filter_item .flexWrap.ttbm-list-mode .filter_item {
-		flex-direction: column !important;
+		flex-direction: column;
 	}
 
 	.all_filter_item .flexWrap.ttbm-list-mode .ttbm-gc-image-wrap {

--- a/assets/frontend/ttbm_registration.js
+++ b/assets/frontend/ttbm_registration.js
@@ -472,21 +472,23 @@ $(document).on('change', '.ttbm-sort-select', function () {
         // =========================================================
         // Top Filter Tabs
         // =========================================================
-        $('.ttbm-tab-btn').on('click', function () {
+        $(document).on('click', '.ttbm-tab-btn', function () {
 
             $('.ttbm-tab-btn').removeClass('ttbm-tab-active');
             $(this).addClass('ttbm-tab-active');
 
             let filter = $(this).data('filter-tab');
+            let parent = $(this).closest('.ttbm_filter_area');
 
-            // Example filtering logic
-            // You can customize using your own date field
+            let now = new Date();
+            now.setHours(0, 0, 0, 0);
 
-            $('.filter_item').each(function () {
+            let weekEnd = new Date(now);
+            weekEnd.setDate(weekEnd.getDate() + 7);
+
+            parent.find('.filter_item').each(function () {
 
                 let item = $(this);
-
-                // if no data-date exists then show all
                 let itemDate = item.attr('data-date');
 
                 if (!itemDate || filter === 'all') {
@@ -494,22 +496,15 @@ $(document).on('change', '.ttbm-sort-select', function () {
                     return;
                 }
 
-                let now = new Date();
-                let tourDate = new Date(itemDate);
-
-                let diffTime = tourDate - now;
-                let diffDays = diffTime / (1000 * 60 * 60 * 24);
+                let tourDate = new Date(itemDate + 'T00:00:00');
 
                 if (filter === 'week') {
-
-                    if (diffDays <= 7 && diffDays >= 0) {
+                    if (tourDate >= now && tourDate <= weekEnd) {
                         item.show();
                     } else {
                         item.hide();
                     }
-
                 } else if (filter === 'month') {
-
                     if (
                         tourDate.getMonth() === now.getMonth() &&
                         tourDate.getFullYear() === now.getFullYear()
@@ -518,9 +513,7 @@ $(document).on('change', '.ttbm-sort-select', function () {
                     } else {
                         item.hide();
                     }
-
                 } else if (filter === 'year') {
-
                     if (tourDate.getFullYear() === now.getFullYear()) {
                         item.show();
                     } else {
@@ -528,6 +521,21 @@ $(document).on('change', '.ttbm-sort-select', function () {
                     }
                 }
             });
+
+            // Update "Showing X of Y" count after tab filter
+            let visibleCount = parent.find('.filter_item:visible').length;
+            let totalCount   = parent.find('.filter_item').length;
+            parent.find('.qty_count').html(visibleCount);
+            parent.find('.total_filter_qty').html(totalCount);
+
+            // Show/hide the empty-result notice
+            if (visibleCount === 0) {
+                parent.find('.search_result_empty').slideDown('fast');
+                parent.find('.filter_short_result').slideUp('fast');
+            } else {
+                parent.find('.search_result_empty').slideUp('fast');
+                parent.find('.filter_short_result').slideDown('fast');
+            }
         });
 
         // =========================================================
@@ -552,16 +560,6 @@ $(document).on('change', '.ttbm-sort-select', function () {
             });
         });
 
-        // =========================================================
-        // Reset Filter When Clicking "All Tours"
-        // =========================================================
-        $('[data-filter-tab="all"]').on('click', function () {
-
-            $('.filter_item').show();
-
-            $('.ttbm_item_filter_by_activity').removeClass('active');
-
-        });
 
         // =========================================================
         // Mobile Left Filter Toggle

--- a/assets/mp_style/ttbm_plugin_global.js
+++ b/assets/mp_style/ttbm_plugin_global.js
@@ -884,7 +884,7 @@ function ttbm_sticky_management() {
                 value = value + (value ? separator : '') + currentValue;
             }
         }).promise().done(function () {
-            parent.find('input[type="hidden"]').val(value);
+            parent.find('input[type="hidden"]').val(value).trigger('change');
         });
     });
     // radio

--- a/inc/TTBM_Tour_List.php
+++ b/inc/TTBM_Tour_List.php
@@ -356,7 +356,10 @@
 								<?php } ?>
 
 								data-price="<?php echo esc_attr(TTBM_Function::get_tour_start_price( $ttbm_post_id )); ?>"
-								data-date="<?php echo esc_attr(get_the_date('Y-m-d', $tour_id)); ?>"
+								data-date="<?php
+									$upcoming = TTBM_Global_Function::get_post_info($tour_id, 'ttbm_upcoming_date');
+									echo esc_attr($upcoming ? gmdate('Y-m-d', strtotime($upcoming)) : get_the_date('Y-m-d', $tour_id));
+								?>"
 								
                             >
                                 <input type="hidden" name="ttbm_item_activities" value="<?php echo esc_attr(TTBM_Function::get_taxonomy_name_to_id_string($tour_id, 'ttbm_tour_activities', 'ttbm_tour_activities')); ?>"/>


### PR DESCRIPTION
- Use delegated click handling for tour-list date tabs so dynamically rendered shortcode content responds reliably.\n- Scope date-tab filtering to the current tour-list shortcode wrapper instead of all page items.\n- Filter week/month/year tabs against each card's upcoming tour date and update visible result counts plus empty-result state.\n- Trigger hidden filter input change events when checkbox aggregates are rebuilt so sidebar filters refresh immediately.\n- Prevent checkbox/radio controls from firing duplicate filter change handling.\n- Use ttbm_upcoming_date for tour-list card data-date fallback to post date only when upcoming date is missing.\n- Relax list-mode CSS !important rules so JS show/hide states can control filtered results.\n\nVerification:\n- php -l inc/TTBM_Tour_List.php