### PR TITLE
fix: hotel expired label, checkout total price, and wishlist toast notifications

### DIFF
--- a/assets/frontend/ttbm_script.js
+++ b/assets/frontend/ttbm_script.js
@@ -284,6 +284,48 @@
     }
 
 
+	// ═══ Toast Notification ════════════════════════════════════════
+	function ttbmShowToast(message, type, duration, html) {
+		type = type || 'info';
+		duration = duration || 3500;
+		var wrap = $('#ttbm-toast-wrap');
+		if (!wrap.length) {
+			wrap = $('<div id="ttbm-toast-wrap" class="ttbm-toast-wrap"></div>');
+			$('body').append(wrap);
+		}
+		var item = $('<div class="ttbm-toast-item ttbm-toast-' + type + '"></div>');
+		if (html) {
+			item.html(message);
+		} else {
+			item.text(message);
+		}
+		var closeBtn = $('<button type="button" class="ttbm-toast-close">&times;</button>');
+		item.append(closeBtn);
+		wrap.append(item);
+		// Force reflow for transition
+		void wrap[0].offsetWidth;
+		wrap.addClass('ttbm-toast-visible');
+
+		var timer = setTimeout(function() {
+			item.fadeOut(250, function() {
+				$(this).remove();
+				if (!wrap.children().length) {
+					wrap.removeClass('ttbm-toast-visible');
+				}
+			});
+		}, duration);
+
+		closeBtn.on('click', function() {
+			clearTimeout(timer);
+			item.fadeOut(200, function() {
+				$(this).remove();
+				if (!wrap.children().length) {
+					wrap.removeClass('ttbm-toast-visible');
+				}
+			});
+		});
+	}
+
 	// ═══ Wishlist Toggle ═══════════════════════════════════════════
 	$(document).on('click', '.ttbm-gc-wishlist', function(e) {
 		e.preventDefault();
@@ -309,6 +351,11 @@
 					if (response.data.in_wishlist) {
 						btn.addClass('active');
 						icon.removeClass('mi-heart').addClass('mi-wishlist-heart');
+						var toastMsg = 'This tour added in wishlist. For check go to my-account wishlist section';
+						if (ttbm_ajax.wishlist_url) {
+							toastMsg = 'This tour added in wishlist. <a href="' + ttbm_ajax.wishlist_url + '">Go to Wishlist</a>';
+						}
+						ttbmShowToast(toastMsg, 'success', 4000, true);
 					} else {
 						btn.removeClass('active');
 						icon.removeClass('mi-wishlist-heart').addClass('mi-heart');
@@ -350,6 +397,7 @@
 			success: function(response) {
 				if (response.success && !response.data.in_wishlist) {
 					btn.closest('.ttbm-wishlist-item').fadeOut(300, function() { $(this).remove(); });
+					ttbmShowToast('Removed from wishlist.', 'info', 3000, false);
 				}
 			}
 		});

--- a/inc/TTBM_Booking.php
+++ b/inc/TTBM_Booking.php
@@ -103,7 +103,10 @@
 		}
 		public function booking_panel($tour_id, $tour_date = '', $hotel_id = '') {
 				$tour_date = $tour_date ?: current(TTBM_Function::get_date($tour_id));
-				$tour_date = TTBM_Function::get_date_by_time_check($tour_id, $tour_date, '');
+				$ttbm_type = TTBM_Function::get_tour_type($tour_id);
+				if ($ttbm_type != 'hotel') {
+					$tour_date = TTBM_Function::get_date_by_time_check($tour_id, $tour_date, '');
+				}
 				$tour_start_datetime = $this->normalize_tour_date($tour_id, $tour_date);
 				$tour_start_datetime = $tour_start_datetime ?: $tour_date;
 				$tour_end_date = TTBM_Global_Function::get_post_info($tour_id, 'ttbm_travel_end_date');

--- a/inc/TTBM_Dependencies.php
+++ b/inc/TTBM_Dependencies.php
@@ -83,7 +83,8 @@
 
 				wp_localize_script('ttbm_script', 'ttbm_ajax', array(
 					'ajax_url' => admin_url('admin-ajax.php'),
-					'nonce' => wp_create_nonce('ttbm_frontend_nonce')
+					'nonce' => wp_create_nonce('ttbm_frontend_nonce'),
+					'wishlist_url' => wc_get_account_endpoint_url('ttbm-wishlist')
 				));
 				do_action('ttbm_frontend_script');
 			}

--- a/inc/TTBM_Hotel_Booking.php
+++ b/inc/TTBM_Hotel_Booking.php
@@ -244,15 +244,15 @@
 				$room_output .= '<div class="ttbm_hotel_ordered_room_list">';
 				foreach ($room_data_info as $roomName => $info) {
 					$qty = $info['quantity'];
-					$price = $info['price'];
-					$total = $price * $qty * $days;
+					$room_price = $info["price"];
+					$total = $room_price * $qty * $days;
 					// Format room name: insert space before capital letters except first
 					$formattedRoomName = isset($info['name']) ? $info['name'] : preg_replace('/(?<!^)([A-Z])/', ' $1', $roomName);
 					// Build the output
 					$room_output .= " <div class='ttbm_hotel_room'>";
 					$room_output .= " <div class='ttbm_hotel_room_name'> Room Name: {$formattedRoomName}</div> ";
 					$room_output .= " <div class='ttbm_hotel_qty'>Qty: {$qty}</div> ";
-					$room_output .= " <div class='ttbm_hotel_price'>Price: ( " . number_format($price, 2) . " {$currency_symbol} x {$qty} x {$days} ) = " . number_format($total, 2) . " {$currency_symbol}</div> ";
+					$room_output .= " <div class='ttbm_hotel_price'>Price: ( " . number_format($room_price, 2) . " {$currency_symbol} x {$qty} x {$days} ) = " . number_format($total, 2) . " {$currency_symbol}</div> ";
 					$room_output .= " </div> ";
 				}
 				$room_output .= '</div>';
@@ -260,7 +260,7 @@
 				if (!$post_id || !wc_get_product($post_id)) {
 					wp_send_json_error(['message' => __('The selected hotel is not linked to a purchasable product.', 'tour-booking-manager')]);
 				}
-				$quantity = intval(wp_unslash(20));
+				$quantity = 1;
 				$hotel_info = array();
 				$hotel_info['hotel_id'] = $hotel_id;
 				$hotel_info['ttbm_checkin_date'] = $check_in;

--- a/inc/TTBM_Wishlist.php
+++ b/inc/TTBM_Wishlist.php
@@ -364,6 +364,17 @@ if ( ! class_exists( 'TTBM_Wishlist' ) ) {
 			.ttbm-wishlist-view-list .ttbm-wishlist-explore-btn{display:inline-block;background:#6c47ff;color:#fff !important;padding:10px 24px;border-radius:8px;text-decoration:none;font-size:14px;font-weight:600;transition:background .2s;align-self:flex-start;}
 			.ttbm-wishlist-view-list .ttbm-wishlist-explore-btn:hover{background:#5a3be0;color:#fff !important;}
 
+			/* ── Toast Notification ─────────────────────────────── */
+			.ttbm-toast-wrap{position:fixed;bottom:28px;left:50%;transform:translateX(-50%) translateY(20px);z-index:999999;display:flex;flex-direction:column;gap:10px;align-items:center;pointer-events:none;transition:transform .35s cubic-bezier(.22,1,.36,1),opacity .35s ease;opacity:0;}
+			.ttbm-toast-wrap.ttbm-toast-visible{transform:translateX(-50%) translateY(0);opacity:1;}
+			.ttbm-toast-item{background:#222;color:#fff;padding:14px 22px;border-radius:10px;font-size:14px;font-weight:500;line-height:1.5;box-shadow:0 8px 28px rgba(0,0,0,.25);display:flex;align-items:center;gap:10px;pointer-events:auto;max-width:420px;text-align:center;}
+			.ttbm-toast-item.ttbm-toast-success{background:#1a7a3e;}
+			.ttbm-toast-item.ttbm-toast-info{background:#6c47ff;}
+			.ttbm-toast-item a{color:#ffd700;text-decoration:underline;font-weight:600;}
+			.ttbm-toast-item a:hover{color:#fff;}
+			.ttbm-toast-item .ttbm-toast-close{background:none;border:none;color:#fff;font-size:16px;line-height:1;cursor:pointer;padding:0 0 0 6px;opacity:.7;}
+			.ttbm-toast-item .ttbm-toast-close:hover{opacity:1;}
+
 			/* ── List View Responsive ─────────────────────────────── */
 			@media (max-width:767px) {
 			.ttbm-wishlist-view-list .ttbm-wishlist-item{flex-direction:column !important;}

--- a/templates/layout/related_tour.php
+++ b/templates/layout/related_tour.php
@@ -36,14 +36,6 @@
 		$grid_class=$related_tour_count <= $num_of_tour?'grid_'.$num_of_tour:'';
 		$div_class=$related_tour_count==1?'flexWrap modern':'flexWrap grid';
 		?>
-			<?php
-				// Debug: output first related item's ID and thumbnail URL as an HTML comment (non-visible)
-				$first_related_id = is_array($related_tours) && ! empty( $related_tours ) ? reset( $related_tours ) : '';
-				if ( $first_related_id ) {
-					$first_thumb = TTBM_Global_Function::get_image_url( $first_related_id );
-					echo '<!-- TTBM DEBUG: first related id=' . esc_html( $first_related_id ) . ' thumb=' . esc_url( $first_thumb ) . ' -->';
-				}
-			?>
 			<div class='ttbm_style related-hotel' id="ttbm_related_tour">
 			<h2 class="content-title"><?php esc_html_e( 'You may like ', 'tour-booking-manager' ) ?></h2>
 			<?php

--- a/templates/list/grid_list_style.php
+++ b/templates/list/grid_list_style.php
@@ -25,24 +25,6 @@ $term_count   = 3;
 
 	<?php /* Tour thumbnail */ ?>
 	<div class="ttbm-gc-thumb" data-bg-image="<?php echo esc_attr( $thumbnail ); ?>"></div>
-	<?php /* Fallback img shown only when JS/CSS background fails */ ?>
-	<img class="ttbm-gc-thumb-fallback" src="<?php echo esc_url( $thumbnail ); ?>" alt="" style="display:none;width:100%;height:220px;object-fit:cover;border-radius:0;" />
-	<script type="text/javascript">(function($){
-		$(function(){
-			var $thumb = $(this).closest && $(this).closest('.ttbm-gc-image-wrap') ? $(this) : null;
-			$('.ttbm-gc-image-wrap').each(function(){
-				var $wrap = $(this);
-				var $bg = $wrap.find('.ttbm-gc-thumb');
-				var $fb = $wrap.find('.ttbm-gc-thumb-fallback');
-				if ($bg.length && $fb.length) {
-					var bgImage = $bg.css('background-image');
-					if (!bgImage || bgImage === 'none' || bgImage === 'initial' || bgImage.indexOf('url(') === -1) {
-						$fb.show();
-					}
-				}
-			});
-		});
-	})(jQuery);</script>
 
 	<?php /* Duration badge overlaid at bottom of image */ ?>
 	<div class="ttbm-gc-duration-badge fdColumn" data-placeholder>


### PR DESCRIPTION


## Bug Fixes

### 1. Fixed "Expired!" incorrectly shown on hotel-based tours
- **File:** `inc/TTBM_Booking.php`
- **Problem:** Hotel tours use flexible date ranges independent of the parent tour schedule. The booking panel was calling `TTBM_Function::get_date_by_time_check()` which validated the selected hotel date against the tour repeated dates, causing "Expired!" to display when the hotel date fell outside the tour date range.
- **Fix:** Skip `get_date_by_time_check()` validation when `$ttbm_type == hotel`.

### 2. Fixed checkout showing single room price instead of total
- **File:** `inc/TTBM_Hotel_Booking.php`
- **Problems:**
  1. Loop variable `$price` overwrote the pre-calculated total price (`$booking_request[total_price]`).
  2. Cart quantity was hardcoded to `20` instead of `1` (total price is already pre-calculated).
- **Fix:**
  1. Renamed loop variable to `$room_price`.
  2. Changed quantity to `1` so WooCommerce uses the injected `custom_price` / `ttbm_tp` meta correctly.

## Feature: Wishlist Toast Notifications

### 3. Toast notification when adding a tour to wishlist
- **Files:** `assets/frontend/ttbm_script.js`, `inc/TTBM_Wishlist.php`, `inc/TTBM_Dependencies.php`
- **Behavior:** Clicking the heart icon on a tour card now shows a green success toast:
  > "This tour added in wishlist. [Go to Wishlist]"
- The "Go to Wishlist" link navigates to the WooCommerce my-account wishlist endpoint (`/my-account/ttbm-wishlist/`).
- Added `wishlist_url` to the localized `ttbm_ajax` JS object.

### 4. Toast notification when removing a tour from My Account wishlist
- **File:** `assets/frontend/ttbm_script.js`
- **Behavior:** Clicking the remove button on the My Account wishlist page shows a purple info toast:
  > "Removed from wishlist."
- The wishlist item still fades out and is removed from the DOM as before.

## UI Polish
- Added reusable `ttbmShowToast()` JavaScript function with auto-dismiss, close button, and HTML content support.
- Added toast CSS styles to the existing wishlist footer stylesheet.

## Cleanup
- Removed debug HTML comment from `templates/layout/related_tour.php`.
- Removed fallback image inline script from `templates/list/grid_list_style.php`.