### PR TITLE
Fix: Hotel room display bug + limit feature tags to 5 with expand button

### DIFF
--- a/assets/frontend/ttbm_hotel_lists.css
+++ b/assets/frontend/ttbm_hotel_lists.css
@@ -907,6 +907,31 @@
     font-size: 12px;
 }
 
+.ttbm_hdc_tag_hidden {
+    display: none !important;
+}
+
+.ttbm_hdc_tags.ttbm_show_all .ttbm_hdc_tag_hidden {
+    display: inline-flex !important;
+}
+
+.ttbm_hdc_tag_more {
+    cursor: pointer;
+    background: #5b3cbe;
+    color: #fff;
+    border-color: #5b3cbe;
+    font-weight: 600;
+}
+
+.ttbm_hdc_tag_more:hover {
+    background: #4a2fa8;
+    border-color: #4a2fa8;
+}
+
+.ttbm_hdc_tags.ttbm_show_all .ttbm_hdc_tag_more {
+    display: none !important;
+}
+
 /* Divider */
 .ttbm_hdc_divider {
     border: none;

--- a/assets/frontend/ttbm_hotel_script.js
+++ b/assets/frontend/ttbm_hotel_script.js
@@ -415,6 +415,10 @@ jQuery(document).ready(function ($) {
 
 jQuery(window).on('load', function () {
     jQuery(function ($) {
+        // Only auto-load rooms on standalone hotel detail pages (not tour pages)
+        if ($('#ttbm_booking_hotel_id').length < 1) {
+            return;
+        }
         let current = $('.ttbm_hotel_item').first();
         let hotel_id = $("#ttbm_booking_hotel_id").val();
         hotel_id = hotel_id ? hotel_id.trim() : '';

--- a/templates/ticket/hotel_default_selection.php
+++ b/templates/ticket/hotel_default_selection.php
@@ -83,17 +83,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 								<!-- Row 4: feature tag pills -->
 								<?php if ( ! empty( $hotel_feat_ids ) ) : ?>
 								<div class="ttbm_hdc_tags">
-									<?php foreach ( $hotel_feat_ids as $feat_id ) :
+									<?php 
+									$feat_count = 0;
+									$total_feats = count( $hotel_feat_ids );
+									foreach ( $hotel_feat_ids as $feat_id ) :
 										$term = get_term( intval( $feat_id ), 'ttbm_hotel_features_list' );
 										if ( $term && ! is_wp_error( $term ) ) :
 											$icon = get_term_meta( $term->term_id, 'ttbm_hotel_feature_icon', true );
 											$icon = $icon ? $icon : 'fas fa-check';
+											$feat_count++;
+											$hidden_class = $feat_count > 5 ? ' ttbm_hdc_tag_hidden' : '';
 									?>
-										<span class="ttbm_hdc_tag">
+										<span class="ttbm_hdc_tag<?php echo esc_attr( $hidden_class ); ?>">
 											<i class="<?php echo esc_attr( $icon ); ?>"></i>
 											<?php echo esc_html( $term->name ); ?>
 										</span>
 									<?php endif; endforeach; ?>
+									<?php if ( $total_feats > 5 ) : ?>
+										<span class="ttbm_hdc_tag ttbm_hdc_tag_more" onclick="this.parentElement.classList.add('ttbm_show_all'); this.style.display='none';">
+											+<?php echo esc_html( $total_feats - 5 ); ?>
+										</span>
+									<?php endif; ?>
 								</div>
 								<?php endif; ?>
 


### PR DESCRIPTION
Bug Fix - First hotel shows 'No Room available!' on fixed-date tour pages:
- Root cause: jQuery(window).on('load') handler in ttbm_hotel_script.js fires on tour detail pages where #ttbm_booking_hotel_id does not exist, sending an empty hotel_id via AJAX to ttbm_get_hotel_room_list. The server returns 'No Room available!' which gets injected into the first hotel card.
- Fix: Added guard clause at the top of the window.on('load') handler that returns early when $('#ttbm_booking_hotel_id').length < 1. This element only exists on standalone hotel detail pages, so the auto-load is now correctly skipped on tour pages.
- File: assets/frontend/ttbm_hotel_script.js (line 418)

Feature - Limit hotel feature tags to 5 with expand button:
- Initially shows only the first 5 feature tags per hotel card
- Displays a purple '+N' button showing the count of hidden tags
- Clicking the button reveals all tags and hides the button
- Files: templates/ticket/hotel_default_selection.php (PHP logic) assets/frontend/ttbm_hotel_lists.css (CSS show/hide rules)