### PR TITLE
Fix: This Week/Month/Year tab filters integrate with Load More pagina…

### DIFF
--- a/assets/frontend/filter_pagination.js
+++ b/assets/frontend/filter_pagination.js
@@ -422,7 +422,10 @@
 		}
 	}
 	function get_item_class(parent, items = '.filter_item') {
-		if (parent.find('.filter_item.search_on').length > 0 || parent.find('.filter_item.search_of').length > 0) {
+		if (parent.find('.filter_item.ttbm-tab-hidden').length > 0) {
+			items = '.filter_item:not(.ttbm-tab-hidden)';
+			parent.find('.filter_item.ttbm-tab-hidden').hide();
+		} else if (parent.find('.filter_item.search_on').length > 0 || parent.find('.filter_item.search_of').length > 0) {
 			items = '.filter_item.search_on';
 			parent.find('.filter_item.search_of').slideUp('fast');
 		}

--- a/assets/frontend/filter_pagination.js
+++ b/assets/frontend/filter_pagination.js
@@ -401,6 +401,7 @@
 				filter_qty_palace(parent, items_class);
 				pagination_management(parent, pagination_page);
 				placeholderLoaderRemove(all_item);
+				parent.find('.filter_item.ttbm-tab-hidden').stop(true, true).hide();
 			});
 		});
 	}

--- a/assets/frontend/ttbm_registration.js
+++ b/assets/frontend/ttbm_registration.js
@@ -478,58 +478,81 @@ $(document).on('change', '.ttbm-sort-select', function () {
             $(this).addClass('ttbm-tab-active');
 
             let filter = $(this).data('filter-tab');
+
             let parent = $(this).closest('.ttbm_filter_area');
+            if (!parent.length) parent = $(this).closest('.all_filter_item').parent();
+            if (!parent.find('.filter_item').length) parent = $(document);
+
+            let perPage = parseInt(parent.find('input[name="pagination_per_page"]').val(), 10);
+            if (isNaN(perPage) || perPage < 1) perPage = parent.find('.filter_item').length;
 
             let now = new Date();
             now.setHours(0, 0, 0, 0);
 
-            let weekEnd = new Date(now);
-            weekEnd.setDate(weekEnd.getDate() + 7);
+            // Calendar week: Monday (start) to Sunday (end)
+            let dayOfWeek = now.getDay(); // 0 = Sun, 1 = Mon, ... 6 = Sat
+            let daysSinceMonday = (dayOfWeek + 6) % 7;
+            let weekStart = new Date(now);
+            weekStart.setDate(weekStart.getDate() - daysSinceMonday);
+            let weekEnd = new Date(weekStart);
+            weekEnd.setDate(weekEnd.getDate() + 6);
 
+            // Step 1: classify every card — match vs. not match
             parent.find('.filter_item').each(function () {
 
                 let item = $(this);
                 let itemDate = item.attr('data-date');
+                let matches = false;
 
-                if (!itemDate || filter === 'all') {
-                    item.show();
-                    return;
+                if (filter === 'all' || !itemDate) {
+                    matches = true;
+                } else {
+                    let tourDate = new Date(itemDate + 'T00:00:00');
+                    if (filter === 'week') {
+                        matches = (tourDate >= weekStart && tourDate <= weekEnd);
+                    } else if (filter === 'month') {
+                        matches = (tourDate.getMonth() === now.getMonth() &&
+                                   tourDate.getFullYear() === now.getFullYear());
+                    } else if (filter === 'year') {
+                        matches = (tourDate.getFullYear() === now.getFullYear());
+                    }
                 }
 
-                let tourDate = new Date(itemDate + 'T00:00:00');
+                item.toggleClass('ttbm-tab-hidden', !matches);
+            });
 
-                if (filter === 'week') {
-                    if (tourDate >= now && tourDate <= weekEnd) {
-                        item.show();
-                    } else {
-                        item.hide();
-                    }
-                } else if (filter === 'month') {
-                    if (
-                        tourDate.getMonth() === now.getMonth() &&
-                        tourDate.getFullYear() === now.getFullYear()
-                    ) {
-                        item.show();
-                    } else {
-                        item.hide();
-                    }
-                } else if (filter === 'year') {
-                    if (tourDate.getFullYear() === now.getFullYear()) {
-                        item.show();
-                    } else {
-                        item.hide();
-                    }
+            // Step 2: paginate within the matched set (first perPage visible, rest hidden)
+            let matched = parent.find('.filter_item').not('.ttbm-tab-hidden');
+            let totalMatched = matched.length;
+
+            parent.find('.filter_item.ttbm-tab-hidden').hide();
+            matched.each(function (idx) {
+                let item = $(this);
+                if (idx < perPage) {
+                    item.removeClass('dNone').show();
+                } else {
+                    item.hide();
                 }
             });
 
-            // Update "Showing X of Y" count after tab filter
-            let visibleCount = parent.find('.filter_item:visible').length;
-            let totalCount   = parent.find('.filter_item').length;
-            parent.find('.qty_count').html(visibleCount);
-            parent.find('.total_filter_qty').html(totalCount);
+            // Step 3: reset & toggle Load More / pagination area
+            let loadMoreBtn = parent.find('.pagination_load_more');
+            loadMoreBtn.attr('data-load-more', '0').removeAttr('disabled');
+            parent.find('[data-pagination]').removeClass('active_pagination');
+            parent.find('[data-pagination="0"]').addClass('active_pagination');
 
-            // Show/hide the empty-result notice
-            if (visibleCount === 0) {
+            if (totalMatched <= perPage) {
+                parent.find('.pagination_area').slideUp(150);
+            } else {
+                parent.find('.pagination_area').slideDown(150);
+            }
+
+            // Step 4: update "Showing X of Y" + empty-state notice
+            let visibleCount = Math.min(perPage, totalMatched);
+            parent.find('.qty_count').html(visibleCount);
+            parent.find('.total_filter_qty').html(totalMatched);
+
+            if (totalMatched === 0) {
                 parent.find('.search_result_empty').slideDown('fast');
                 parent.find('.filter_short_result').slideUp('fast');
             } else {

--- a/assets/frontend/ttbm_registration.js
+++ b/assets/frontend/ttbm_registration.js
@@ -472,19 +472,62 @@ $(document).on('change', '.ttbm-sort-select', function () {
         // =========================================================
         // Top Filter Tabs
         // =========================================================
-        // Re-assert tab-filter hiding after pagination actions. Some flows
-        // (Load More click handler in filter_pagination.js) iterate cards
-        // and call slideDown, which can re-show .ttbm-tab-hidden items.
-        function ttbmEnforceTabFilter(parent) {
-            if (!parent || !parent.length) parent = $(document);
-            parent.find('.filter_item.ttbm-tab-hidden').stop(true, true).hide();
-        }
-        $(document).on('click', '.ttbm_filter_area .pagination_area .pagination_load_more, .ttbm_filter_area .pagination_area [data-pagination]', function () {
-            let p = $(this).closest('.ttbm_filter_area');
-            // Run after the original handler's slideDown/slideUp animations complete
-            setTimeout(function () { ttbmEnforceTabFilter(p); }, 50);
-            setTimeout(function () { ttbmEnforceTabFilter(p); }, 300);
-        });
+        // When a tab filter is active, completely take over Load More and
+        // page-number clicks so the legacy filter_pagination.js handler
+        // cannot iterate and slideDown the hidden cards.
+        document.addEventListener('click', function (evt) {
+            let target = evt.target.closest('.pagination_load_more, [data-pagination]');
+            if (!target) return;
+            let area = target.closest('.ttbm_filter_area');
+            if (!area) return;
+            if (!area.querySelector('.filter_item.ttbm-tab-hidden')) return;
+
+            evt.stopImmediatePropagation();
+            evt.preventDefault();
+
+            let $area = $(area);
+            let matched = $area.find('.filter_item').not('.ttbm-tab-hidden');
+            let totalMatched = matched.length;
+            let pp = parseInt($area.find('input[name="pagination_per_page"]').val(), 10);
+            if (isNaN(pp) || pp < 1) pp = totalMatched;
+
+            let page;
+            if (target.classList.contains('pagination_load_more')) {
+                page = parseInt(target.getAttribute('data-load-more'), 10) || 0;
+                let hiddenInMatched = matched.filter(':hidden').length;
+                page = hiddenInMatched > 0 ? page + 1 : 0;
+                target.setAttribute('data-load-more', String(page));
+            } else {
+                page = parseInt(target.getAttribute('data-pagination'), 10) || 0;
+                $area.find('[data-pagination]').removeClass('active_pagination');
+                $(target).addClass('active_pagination');
+            }
+
+            let style = $area.find('input[name="pagination_style"]').val();
+            let startIdx = (style === 'load_more') ? 0 : page * pp;
+            let endIdx = (style === 'load_more') ? (page + 1) * pp : (page + 1) * pp;
+
+            matched.each(function (idx) {
+                if (idx >= startIdx && idx < endIdx) {
+                    $(this).removeClass('dNone').show();
+                } else {
+                    $(this).hide();
+                }
+            });
+            $area.find('.filter_item.ttbm-tab-hidden').hide();
+
+            let visibleNow = matched.filter(':visible').length;
+            $area.find('.qty_count').html(visibleNow);
+            $area.find('.total_filter_qty').html(totalMatched);
+
+            if (style === 'load_more') {
+                if (matched.filter(':hidden').length === 0) {
+                    $area.find('.pagination_load_more').attr('disabled', 'disabled');
+                } else {
+                    $area.find('.pagination_load_more').removeAttr('disabled');
+                }
+            }
+        }, true);
 
         $(document).on('click', '.ttbm-tab-btn', function () {
 

--- a/assets/frontend/ttbm_registration.js
+++ b/assets/frontend/ttbm_registration.js
@@ -472,6 +472,20 @@ $(document).on('change', '.ttbm-sort-select', function () {
         // =========================================================
         // Top Filter Tabs
         // =========================================================
+        // Re-assert tab-filter hiding after pagination actions. Some flows
+        // (Load More click handler in filter_pagination.js) iterate cards
+        // and call slideDown, which can re-show .ttbm-tab-hidden items.
+        function ttbmEnforceTabFilter(parent) {
+            if (!parent || !parent.length) parent = $(document);
+            parent.find('.filter_item.ttbm-tab-hidden').stop(true, true).hide();
+        }
+        $(document).on('click', '.ttbm_filter_area .pagination_area .pagination_load_more, .ttbm_filter_area .pagination_area [data-pagination]', function () {
+            let p = $(this).closest('.ttbm_filter_area');
+            // Run after the original handler's slideDown/slideUp animations complete
+            setTimeout(function () { ttbmEnforceTabFilter(p); }, 50);
+            setTimeout(function () { ttbmEnforceTabFilter(p); }, 300);
+        });
+
         $(document).on('click', '.ttbm-tab-btn', function () {
 
             $('.ttbm-tab-btn').removeClass('ttbm-tab-active');
@@ -542,9 +556,9 @@ $(document).on('change', '.ttbm-sort-select', function () {
             parent.find('[data-pagination="0"]').addClass('active_pagination');
 
             if (totalMatched <= perPage) {
-                parent.find('.pagination_area').slideUp(150);
+                parent.find('.pagination_area').hide();
             } else {
-                parent.find('.pagination_area').slideDown(150);
+                parent.find('.pagination_area').show();
             }
 
             // Step 4: update "Showing X of Y" + empty-state notice


### PR DESCRIPTION
…tion

- Make tab filter scope tolerant of template variations by falling back through .ttbm_filter_area, .all_filter_item parent, and document
- Change This Week to use calendar week (Monday-Sunday) instead of sliding 7-day window
- Strip dNone class so paginated items are visible when filter matches
- Mark non-matching cards with .ttbm-tab-hidden and apply per-page limit to matched set so "Showing X of Y" reflects filtered counts and pagination area hides when filtered <= perPage
- Teach get_item_class() in filter_pagination.js to exclude .ttbm-tab-hidden so Load More pages within the filtered set