### PR TITLE
Prepare 2.2.0 release notes and bump version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: tour booking, travel agency, travel booking, tour operator, hotel booking
 Requires at least: 4.4.0
 Tested up to: 7.0
 Requires PHP: 7.0
-Stable tag: 2.1.9
+Stable tag: 2.2.0
 License: GPL v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -16,6 +16,8 @@ Travelly is a WordPress tour and travel booking plugin for WooCommerce. Sell tou
 **Travelly – Tour & Travel Booking Manager for WooCommerce** is a complete WordPress booking plugin built for travel agencies, tour operators, and hotel owners who want to sell and manage bookings directly from their website. Launch a fully functional travel booking site in under five minutes, no coding required.
  
 With Travelly, you can create unlimited tour packages, set custom pricing and schedules, manage guest information, and accept payments through any WooCommerce-supported gateway — all from your familiar WordPress dashboard.
+
+Prefer to run without WooCommerce? Switch to **Custom** booking mode and Travelly handles the whole booking flow itself — its own checkout, its own order records, and the built-in Offline Payment method — with no WooCommerce install required.
 
 Launch your travel booking site in under five minutes using the most feature-rich booking plugin available.
 
@@ -31,13 +33,16 @@ Travelly is one of the most popular free tour and travel booking plugins in the 
 = ✨ Key Features =
  
 * **Full WooCommerce Integration** – Sell tour packages using your existing WooCommerce store and accept payments through every gateway WooCommerce supports (Stripe, PayPal, and more).
+* **Works Without WooCommerce** – Choose Custom booking mode to use Travelly's own checkout, order records, and built-in Offline Payment method instead.
+* **Unified Booking Manager** – One admin screen for every booking, whether it came from WooCommerce or the built-in checkout, with status changes, order notes, and CSV export.
 * **Comprehensive Tour Management** – Add tour name, description, ticket type, quantity, price, category, and organizer.
 * **Extra Services** – Offer optional add-ons with their own price and quantity.
 * **Google Maps Integration** – Show tour locations visually on an interactive map.
-* **Flexible Scheduling** – Set start date, end date, and time options for every tour.
-* **Guest Information** – Capture and manage guest details directly through WooCommerce order details.
+* **Flexible Scheduling** – Set start date, end date, time options, and off-schedule (blocked) dates for every tour.
+* **Guest Information** – Capture and manage guest details directly from the booking details screen.
 * **Hotel Booking Support** – Manage hotel listings alongside your tour packages.
-* **Customer Dashboard & Cancellations** – Let customers view bookings and request cancellations from a self-service dashboard; admins approve or reject requests and set the cancellation window in Travel Settings.
+* **Customer Wishlist** – Let visitors save tours to a wishlist from any listing and review them in their account.
+* **Modern Admin Experience** – Redesigned tour editor with sidebar navigation and autosave, a searchable tour list with Classic/Compact/Modern layouts, plus Welcome and System Status pages.
 * **Responsive & SEO-Friendly Design** – Fast, mobile-friendly booking pages that are optimized for search engines.
 * **Cross-Browser Compatibility** – Consistent experience across all modern browsers.
 * **Multilingual Ready** – Works with WPML and Polylang for multilingual travel websites.
@@ -86,6 +91,9 @@ Display your tours anywhere on your site using flexible shortcodes:
  
 **Tour list with top filter**
 `[ttbm-top-filter style='list']`
+
+**Tour list with modern filter bar**
+`[ttbm-tour-list style='grid' column=3 show='9' pagination='yes']`
  
 **Expired tours only**
 `[travel-list style='list' status='expired']`
@@ -105,12 +113,15 @@ Display your tours anywhere on your site using flexible shortcodes:
 **Hotel list with sidebar filter**
 `[wptravelly-hotel-list sidebar-filter='yes' price-filter='yes']`
  
-**Customer dashboard & cancellations**
-`[ttbm-customer-dashboard]`
- 
+**Booking confirmation page** (used by the built-in checkout in Custom booking mode)
+`[ttbm-booking-confirmation]`
+
 = 💳 Payment Gateways =
- 
-Travelly works seamlessly with WooCommerce, so every WooCommerce-supported payment gateway — including Stripe, PayPal, and dozens more — is compatible out of the box.
+
+Travelly supports two booking modes, switchable from **Tour Settings → Payments**:
+
+* **WooCommerce mode** – bookings go through the WooCommerce cart and checkout, so every WooCommerce-supported payment gateway (Stripe, PayPal, and dozens more) works out of the box.
+* **Custom mode** – Travelly runs its own checkout and stores its own order records, so you can take bookings with WooCommerce deactivated. **Offline Payment** (bank transfer, pay on arrival, cash) is included free; PayPal and Stripe for Custom mode ship with Travelly PRO.
  
 = 🚀 Premium Features (PRO Version) =
  
@@ -176,9 +187,13 @@ Travelly uses the [Appsero](https://appsero.com) SDK to collect basic telemetry 
 == Frequently Asked Questions ==
  
 = Does Travelly require WooCommerce? =
- 
-Yes. Travelly integrates directly with WooCommerce to handle checkout, orders, and payments, so WooCommerce must be installed and activated.
- 
+
+No longer. Travelly runs in two booking modes. In **WooCommerce mode** it uses the WooCommerce cart, checkout, and payment gateways, exactly as before. In **Custom mode** it uses its own checkout and order records with the built-in Offline Payment method, so tours, hotels, listings, and bookings all work with WooCommerce deactivated. Pick the mode under Tour Settings → Payments.
+
+= Where do bookings show up? =
+
+Under **Tours → Tour Booking**. That screen lists bookings from both engines — WooCommerce orders and built-in checkout orders — so you can change status, add order notes, and export to CSV from one place. Notes added to a WooCommerce booking are written into the real WooCommerce order notes, not a separate copy.
+
 = Can I sell tour packages separately from other WooCommerce products? =
  
 Yes, Travelly lets you sell tours and travel packages as their own product type, independent from regular WooCommerce products.
@@ -199,10 +214,10 @@ Yes, Travelly includes hotel listing and hotel search shortcodes so you can mana
  
 Yes, Travelly is multilingual-ready and works with WPML and Polylang.
  
-= Can customers cancel their own bookings? =
- 
-Yes, add the `[ttbm-customer-dashboard]` shortcode to a page so customers can view orders and request cancellations within the window you set in Travel Settings. Admins can approve or reject each request from the backend.
- 
+= Can visitors save tours for later? =
+
+Yes. When WooCommerce is active, visitors can add tours to a wishlist from any listing and review them under the Wishlist tab in My Account. Admins can see who wishlisted what from the Wishlist tab on the Tour List screen.
+
 = Is there a PRO version with more features? =
  
 Yes, [Travelly PRO](https://mage-people.com/product/woocommerce-tour-and-travel-booking-manager-pro/) adds PDF tickets, custom registration forms, automatic email confirmations, CSV attendee export, and recurring tours.
@@ -213,6 +228,72 @@ Use the [WordPress.org support forum](https://wordpress.org/support/plugin/tour-
 
 
 == Changelog ==
+= 2.2.0 – 28 July 2026 =
+
+**Booking & Payments**
+
+* New: Custom booking mode — Travelly now ships its own checkout and order records, so tours and hotels can be sold with WooCommerce deactivated. Switch modes under Tour Settings → Payments.
+* New: Offline Payment gateway (bank transfer, pay on arrival, cash) included free, with a pluggable gateway API (`ttbm_register_payment_gateways`) that PRO extends with PayPal and Stripe.
+* New: Built-in checkout modal with guest checkout, order review, and a booking confirmation page powered by the new `[ttbm-booking-confirmation]` shortcode.
+* New: Payments settings tab with a booking-mode switch, gateway icons, guest-booking control, and an adaptive admin notice when no payment method is usable.
+* New: "Tour Booking" admin screen listing bookings from both engines — WooCommerce orders and built-in checkout orders — with status changes, order notes, search/filtering, and CSV export. Notes on a WooCommerce booking write into the real WooCommerce order notes.
+* New: Optional login gate on the booking form, with a Confirm Booking button that completes in place.
+* Improved: Booking data is normalized into one shape before display, so tour, date, ticket, guest, and extra-service details render consistently across the checkout, confirmation, and admin screens.
+* Improved: The custom orders screen is fully responsive down to mobile.
+
+**Admin Experience**
+
+* New: Redesigned tour editor — sidebar navigation, deep-linkable tabs, background autosave with toast feedback, skeleton loading, and inline validation for dates, tickets, and pricing.
+* New: Tour List dashboard with AJAX filtering and pagination plus switchable Classic, Compact, and Modern layouts.
+* New: Guides and Ticket Types are now managed as tabs on the Tour List screen with add/edit/delete modals; their separate submenus are hidden.
+* New: Welcome page and a System Status diagnostics page.
+* New: Modular settings architecture with dedicated panels for pricing, dates, extra services, gallery, location, and sidebar, on a modern CSS design-token admin layer.
+* New: Pro Features menu listing the available premium add-ons.
+* New: WooCommerce installer popup and dummy-data import rebuilt as memory-safe stepped AJAX requests, so they no longer time out on small hosts.
+* Improved: Google Maps API key handling and map embedding in location settings.
+* Improved: Ticket type icons can be replaced by clicking the existing icon.
+
+**Front End**
+
+* New: Modern tour details redesign — reworked hero, sticky sidebar CTA, day-wise schedule timeline, expandable inclusions and features, and a scoped stylesheet that stays out of your theme's way.
+* New: Smart theme booking flow with its own date picker, ticket, and extra-service templates.
+* New: Wishlist — save tours from any listing, review them under the My Account Wishlist tab in grid or list view, and see wishlisted tours per customer from the admin Wishlist tab (requires WooCommerce).
+* New: `[ttbm-tour-list]` shortcode with a modern filter bar, "Showing X of Y" counter, and This Week / This Month / This Year tab filters that work together with Load More.
+* New: Auto-related tours, featured image slider, off-schedule (blocked) dates, and per-tour custom titles for tours and hotels.
+* New: New grid list style plus refreshed Lotus, Flora, Blossom, and Orchid cards.
+* Improved: Shortcode output now aligns with the active theme's container width.
+* Improved: Travel translation settings are applied to booking labels.
+* Improved: Korean translations for the modern filter bar; updated language files.
+
+**Performance**
+
+* Improved: Frontend and admin assets only load on pages and screens that need them (filterable via `ttbm_load_assets` and `ttbm_load_admin_assets`).
+* Improved: Asset cache-busting uses the plugin version instead of `time()`, so browser and CDN caches actually work.
+* Improved: Faster list shortcode rendering; list output is capped by `ttbm_list_render_cap` (default 300) with client-side pagination.
+
+**Fixes**
+
+* Fixed: "Undefined array key 0" notice on tour list cards.
+* Fixed: Fatal errors and connection timeouts on the tour list and tour details pages.
+* Fixed: Syntax error in the filter/pagination handler.
+* Fixed: WooCommerce bookings were dropped when the PRO add-on was inactive.
+* Fixed: Extra-service prices were misallocated across tickets; each ticket now gets its correct share.
+* Fixed: Hotel room display bug, hotel expired label, and checkout total price.
+* Fixed: Rooms no longer auto-load outside hotel detail pages.
+* Fixed: Tickets were loaded multiple times when changing the date.
+* Fixed: Wishlist toast feedback on mobile; the admin wishlist table now lists real customers correctly.
+* Fixed: Related tours no longer drop the list when only one result remains.
+* Fixed: Wishlist button is guarded when the wishlist class is unavailable.
+* Fixed: Global settings not saving in some setups; settings tab deep links now resolve to the right tab.
+* Fixed: Numerous responsive and styling issues across list, filter, hotel, and registration views.
+
+**Developer**
+
+* New: `do_action('ttbm_after_ticket_price', $tour_id, $ticket_name, $tour_date)` for injecting markup after a ticket price.
+* New: `apply_filters` hook making booking availability overridable for non-WooCommerce checkouts.
+* New: `ttbm_register_payment_gateways` action for registering custom standalone gateways.
+* Improved: Plugin loading and asset management centralized in `TTBM_Dependencies`.
+
 = 2.1.9 – 15 May 2026 =
 * New: Customer dashboard with booking cancellation requests (`[ttbm-customer-dashboard]`)
 * New: Admin management of cancellation requests with approve/reject and notifications
@@ -245,6 +326,9 @@ Use the [WordPress.org support forum](https://wordpress.org/support/plugin/tour-
 [View the full changelog](https://plugins.trac.wordpress.org/log/tour-booking-manager/)
 
 == Upgrade Notice ==
+
+= 2.2.0 =
+Major update. Travelly can now take bookings without WooCommerce using its own checkout and free Offline Payment method, adds a unified booking manager for both engines, a redesigned admin and tour details page, a customer wishlist, and large performance gains. Back up your site before updating.
 
 = 2.1.9 =
 Adds the new customer dashboard with self-service cancellation requests, plus performance improvements and a starting-price fix. Recommended for all users.

--- a/tour-booking-manager.php
+++ b/tour-booking-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: Tour & Travel Booking Manager for WooCommerce | Tour & Hotel Booking Solution
  * Plugin URI: http://mage-people.com
  * Description: A Complete Tour and Travel Solution for WordPress by MagePeople.
- * Version: 2.1.9
+ * Version: 2.2.0
  * Author: MagePeople Team
  * Author URI: http://www.mage-people.com/
  * Text Domain: tour-booking-manager
@@ -215,7 +215,7 @@ if (!class_exists('TTBM_Woocommerce_Plugin')) {
 					define('TTBM_PLUGIN_URL', plugins_url() . '/' . plugin_basename(dirname(__FILE__)));
 				}
 				if (!defined('TTBM_PLUGIN_VERSION')) {
-					define('TTBM_PLUGIN_VERSION', '2.1.9');
+					define('TTBM_PLUGIN_VERSION', '2.2.0');
 				}
 				require_once TTBM_PLUGIN_DIR . '/inc/TTBM_Dependencies.php';
 				add_action('admin_init', array($this, 'activation_redirect_setup'), 90);


### PR DESCRIPTION
The 2.1.9 build on WordPress.org predates roughly three months of work (27 new PHP files, 24 new assets, ~180 commits since 5 May), so the changelog was missing everything from the custom checkout through the admin redesign.

- Add a 2.2.0 changelog entry grouped into Booking & Payments, Admin Experience, Front End, Performance, Fixes, and Developer.
- Bump Stable tag, the plugin header Version, and TTBM_PLUGIN_VERSION to 2.2.0 in lockstep.
- Update the description, features, payment gateways, and FAQ for the fact that WooCommerce is now optional: Custom booking mode uses the built-in checkout, order records, and free Offline Payment method.
- Document [ttbm-tour-list] and [ttbm-booking-confirmation].
- Drop the [ttbm-customer-dashboard] feature, shortcode, and FAQ claims. That shortcode is registered nowhere in the free or pro plugin; it was carried over from service-booking-manager's readme and had already been removed once in f591e50 before the readme was restored wholesale from WordPress.org in 39e38a8. The 2.1.9 changelog line is left alone since it is already published.