### PR TITLE
fix: allow removing the last Extra Service row

### DIFF
--- a/admin/settings/TTBM_Select_Icon_image.php
+++ b/admin/settings/TTBM_Select_Icon_image.php
@@ -198,11 +198,14 @@
 			}
 			//========Mage Icon library get Icon names======//
 			public static function mi_icon($icon_type = "fi") {
-				$mi_icon_json = file_get_contents(TTBM_PLUGIN_URL . '/assets/mage-icon/data.json');
+				$mi_icon_file = TTBM_PLUGIN_DIR . '/assets/mage-icon/data.json';
+				$mi_icon_json = is_readable($mi_icon_file) ? file_get_contents($mi_icon_file) : '';
 				$mi_icons = json_decode($mi_icon_json, true);
 				$all_icon = [];
-				foreach ($mi_icons as $mi_icon) {
-					$all_icon["{$icon_type} mi-{$mi_icon}"] = $mi_icon;
+				if (is_array($mi_icons)) {
+					foreach ($mi_icons as $mi_icon) {
+						$all_icon["{$icon_type} mi-{$mi_icon}"] = $mi_icon;
+					}
 				}
 				return $all_icon;
 			}

--- a/assets/admin/ttbm_admin_settings.js
+++ b/assets/admin/ttbm_admin_settings.js
@@ -160,7 +160,29 @@ function ttbm_load_sortable_datepicker(parent, item) {
         }
     });
     //=========Remove Setting Item ==============//
+    // Empty an extra service row in place. Extra services are optional, so unlike
+    // ticket types the last row must stay removable - but PHP always renders one
+    // blank row for a tour with no extra services, so clearing it leaves the exact
+    // state the next page load draws instead of a delete that looks undone.
+    function ttbmResetExtraServiceRow($row) {
+        $row.find('input[type="text"], input[type="number"], textarea').val("");
+        $row.find("select").each(function () {
+            this.selectedIndex = 0;
+        });
+        // Reuse the pickers' own clear handlers so the icon/image preview resets
+        // exactly the way it does when cleared by hand.
+        $row.find(".ttbm_add_icon_image_area .ttbm_icon_remove, .ttbm_add_icon_image_area .ttbm_image_remove").trigger("click");
+        $row.find(".ttbm-ticket-field-error").removeClass("ttbm-ticket-field-error");
+        $row.find("input.is-invalid").removeClass("is-invalid");
+    }
+
     $(document).on("click", ".ttbm_item_remove,.ttbm_remove_icon", function (e) {
+        // The icon/image pickers reuse .ttbm_remove_icon for their own clear buttons.
+        // They have dedicated handlers below and must not drag the whole row out with
+        // them when a row happens to have an icon set.
+        if ($(this).closest(".ttbm_add_icon_image_area").length) {
+            return;
+        }
         e.preventDefault();
         let $row = $(this).closest(".ttbm_remove_area");
         let $ticketRows = $row.closest(".ttbm_insert_ticket_type");
@@ -168,15 +190,15 @@ function ttbm_load_sortable_datepicker(parent, item) {
         if ($ticketRows.length && $ticketRows.find("> tr.ttbm_remove_area").length <= 1) {
             return false;
         }
+        if (!confirm("Are You Sure , Remove this row ? \n\n 1. Ok : To Remove . \n 2. Cancel : To Cancel .")) {
+            return false;
+        }
         if ($extraRows.length && $extraRows.find("> tr.ttbm_remove_area").length <= 1) {
-            return false;
-        }
-        if (confirm("Are You Sure , Remove this row ? \n\n 1. Ok : To Remove . \n 2. Cancel : To Cancel .")) {
-            $row.slideUp(250).remove();
+            ttbmResetExtraServiceRow($row);
             return true;
-        } else {
-            return false;
         }
+        $row.slideUp(250).remove();
+        return true;
     });
     $(document).on("click", ".ttbm_add_item", function (e) {
         e.preventDefault();

--- a/inc/TTBM_Custom_Slider.php
+++ b/inc/TTBM_Custom_Slider.php
@@ -121,12 +121,12 @@
 							foreach ($image_ids as $id) {
 								$image_url = TTBM_Global_Function::get_image_url('', $id);
 								$image_url = $image_url ?: TTBM_PLUGIN_URL . '/assets/images/no_image.png';
-								$size = wp_getimagesize($image_url);
+								$metadata = wp_get_attachment_metadata($id);
 								$width = 0;
 								$height = 0;
-								if ($size) {
-									$width = $size[0];
-									$height = $size[1];
+								if (is_array($metadata)) {
+									$width = isset($metadata['width']) ? absint($metadata['width']) : 0;
+									$height = isset($metadata['height']) ? absint($metadata['height']) : 0;
 								}
 								?>
                                 <div class="sliderItem" data-slide-index="<?php echo esc_html($count); ?>" data-target-popup="superSlider" data-placeholder>

--- a/inc/admin/TTBM_Custom_Orders_Page.php
+++ b/inc/admin/TTBM_Custom_Orders_Page.php
@@ -5,8 +5,8 @@
 	/**
 	 * Admin page listing tour orders from BOTH sources: the ttbm_custom_order
 	 * CPT created by TTBM_Custom_Checkout and real WooCommerce orders, merged
-	 * via the free plugin's TTBM_Booking_Normalizer. Tour Bookings → Tour
-	 * Orders: stats bar, filters (search / tour / status / gateway / date
+	 * via the free plugin's TTBM_Booking_Normalizer. Tours → Bookings & Guests:
+	 * stats bar, filters (search / tour / status / gateway / date
 	 * range), pagination, CSV export, per-order detail view (WC orders render
 	 * fully in-plugin, they are not redirected out) and status management that
 	 * keeps the ttbm_booking records in sync for both sources. In the free
@@ -15,7 +15,8 @@
 	 */
 	if (!class_exists('TTBM_Custom_Orders_Page')) {
 		class TTBM_Custom_Orders_Page {
-			const SLUG = 'ttbm_custom_orders';
+			const SLUG = 'ttbm_order_list';
+			const LEGACY_SLUG = 'ttbm_custom_orders';
 			const PER_PAGE = 20;
 			const PRO_URL = 'https://mage-people.com/product/woocommerce-tour-and-travel-booking-manager-pro/';
 			private static $index_cache = null;
@@ -23,7 +24,8 @@
 				return class_exists('TTBM_Woocommerce_Plugin_Pro');
 			}
 			public static function init() {
-				add_action('admin_menu', array(__CLASS__, 'add_menu_page'), 20);
+				add_action('admin_menu', array(__CLASS__, 'add_menu_page'));
+				add_action('admin_init', array(__CLASS__, 'redirect_legacy_page'));
 				add_action('admin_enqueue_scripts', array(__CLASS__, 'enqueue_assets'));
 				add_action('admin_post_ttbm_order_delete', array(__CLASS__, 'handle_delete'));
 				add_action('admin_post_ttbm_orders_export_csv', array(__CLASS__, 'export_csv'));
@@ -235,14 +237,44 @@
 				}
 			}
 			public static function add_menu_page() {
+				$menu_title = esc_html__('Bookings & Guests', 'tour-booking-manager')
+					. ' <span style="display:inline-block;margin-left:5px;padding:1px 5px;border-radius:3px;background:#d63638;color:#fff;font-size:9px;font-weight:700;line-height:1.4;vertical-align:1px;">'
+					. esc_html__('PRO', 'tour-booking-manager')
+					. '</span>';
 				add_submenu_page(
 					'edit.php?post_type=' . TTBM_Function::get_cpt_name(),
-					esc_html__('Tour Booking', 'tour-booking-manager'),
-					esc_html__('Tour Booking', 'tour-booking-manager'),
+					esc_html__('Bookings & Guests', 'tour-booking-manager'),
+					$menu_title,
 					'manage_options',
 					self::SLUG,
 					array(__CLASS__, 'render_page')
 				);
+			}
+			public static function redirect_legacy_page() {
+				$page = isset($_GET['page']) ? sanitize_key(wp_unslash($_GET['page'])) : '';
+				if (self::LEGACY_SLUG !== $page) {
+					return;
+				}
+				if (!current_user_can('manage_options')) {
+					wp_die(esc_html__('You do not have permission to access this page.', 'tour-booking-manager'));
+				}
+				$args = array(
+					'post_type' => TTBM_Function::get_cpt_name(),
+					'page' => self::SLUG,
+				);
+				foreach (array('action', 'order', 'paged') as $key) {
+					if (!isset($_GET[$key])) {
+						continue;
+					}
+					$value = 'order' === $key || 'paged' === $key
+						? absint(wp_unslash($_GET[$key]))
+						: sanitize_key(wp_unslash($_GET[$key]));
+					if ('' !== $value && 0 !== $value) {
+						$args[$key] = $value;
+					}
+				}
+				wp_safe_redirect(add_query_arg($args, admin_url('edit.php')));
+				exit;
 			}
 			public static function enqueue_assets($hook) {
 				if (strpos($hook, self::SLUG) === false) {
@@ -253,7 +285,7 @@
 				// CPT-parent submenu pages can leave $GLOBALS['title'] null, which
 				// trips strip_tags(null) deprecations in admin-header.php on PHP 8+.
 				if (empty($GLOBALS['title'])) {
-					$GLOBALS['title'] = esc_html__('Tour Booking', 'tour-booking-manager');
+					$GLOBALS['title'] = esc_html__('Bookings & Guests', 'tour-booking-manager');
 				}
 			}
 			// Native ttbm_custom_order statuses only — the base of status_choices()'s
@@ -656,7 +688,7 @@
 				<div class="wrap ttbm-co-wrap">
 					<div class="ttbm-co-header">
 						<div>
-							<h1 class="ttbm-co-title"><?php esc_html_e('Tour Booking', 'tour-booking-manager'); ?></h1>
+							<h1 class="ttbm-co-title"><?php esc_html_e('Bookings & Guests', 'tour-booking-manager'); ?></h1>
 							<p class="ttbm-co-subtitle"><?php esc_html_e('All tour bookings — placed through WooCommerce or the custom payment gateways (PayPal, Stripe, Offline).', 'tour-booking-manager'); ?></p>
 						</div>
 					</div>
@@ -767,8 +799,8 @@
 						<div class="ttbm-co-pro-overlay">
 							<div class="ttbm-co-pro-card">
 								<span class="ttbm-co-pro-badge"><span class="dashicons dashicons-lock"></span><?php esc_html_e('PRO', 'tour-booking-manager'); ?></span>
-								<h2><?php esc_html_e('Unlock booking analytics and advanced filters', 'tour-booking-manager'); ?></h2>
-								<p><?php esc_html_e('View revenue insights, search and filter every booking, and export your results to CSV with Tour Booking Manager PRO.', 'tour-booking-manager'); ?></p>
+								<h2><?php esc_html_e('Unlock guest management, booking analytics and advanced filters', 'tour-booking-manager'); ?></h2>
+								<p><?php esc_html_e('View and edit guest details, explore revenue insights, search and filter every booking, and export your results with Tour Booking Manager PRO.', 'tour-booking-manager'); ?></p>
 								<a href="<?php echo esc_url(self::PRO_URL); ?>" target="_blank" rel="noopener noreferrer" class="ttbm-co-pro-cta">
 									<span class="dashicons dashicons-star-filled"></span>
 									<?php esc_html_e('Upgrade to PRO', 'tour-booking-manager'); ?>


### PR DESCRIPTION
The shared row-remove handler refused to act when only one row was left in either .ttbm_insert_ticket_type or .ttbm_insert_extra_service, returning early with no confirm and no feedback. That is correct for ticket types, but extra services are optional and extra_service_item() renders one blank row purely as a starting point, so the delete button was dead whenever a tour had a single extra service.

The last extra service row is now cleared in place instead of blocked. The save routine skips rows without a name, price and qty, so a blank row persists as "no extra services", and the cleared row matches exactly what PHP re-renders - removing the <tr> outright would draw a blank row again on reload and read as a failed delete. Rows beyond the first are still removed outright, and ticket types keep their existing rule.

Also stops the handler from firing for the icon and image pickers, which put ttbm_remove_icon on their own clear buttons: clicking the x on a set icon used to offer to delete the entire row.